### PR TITLE
feat: Add support for Albums and Artists

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,14 @@ Development is currently prioritized for iOS and macOS, however first stable rel
 | Jellyfin    |   ❓   |
 | Funkwhale   |   ❓   |
 
-| Feature               | Status | Notes                                   |
-| --------------------- | :----: | --------------------------------------- |
-| Unified search        |   ✅   |                                         |
-| Unified playlists     |   🟧   | Missing UI for adding songs to playlist |
-| Unified library       |   🟧   | Missing album support (WIP)             |
-| Metadata tagging      |   🟥   | Manual metadata edition is supported    |
-| Media synchronisation |   🟥   |                                         |
-| Lyrics                |   🟥   |                                         |
-
-Dates attributed to each features are a subject to change as they are a very rough estimates at a very early point in development.
-Debugging, life-related things, app design and such might affect them.
-I will try to update the roadmap as the development progresses.
-
-\* – Features considered "optional", unclear whether they will materialize
+| Feature               | Status | Notes                                       |
+| --------------------- | :----: | ------------------------------------------- |
+| Unified search        |   🟧   | Missing filters, only songs right now       |
+| Unified library       |   🟧   | Missing YouTube support and UI to add items |
+| Unified playlists     |   🟧   | Missing UI for adding songs to playlist     |
+| Metadata tagging      |   🟥   | Manual metadata edition is supported        |
+| Media synchronisation |   🟥   |                                             |
+| Lyrics                |   🟥   |                                             |
 
 ## Development
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -30,6 +30,7 @@ export default {
 		plugins: [vue()],
 		root: ".",
 		build: {
+			sourcemap: "inline",
 			emptyOutDir: false,
 			outDir: "./dist/electron/renderer",
 			rollupOptions: {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,6 +17,7 @@ const ALLOWED_URLS = [
 	"https://*.googleapis.com",
 	"https://*.googleusercontent.com",
 	"https://*.mzstatic.com",
+	"https://*.ytimg.com",
 ];
 const ALLOWED_URL_PATTERNS = ALLOWED_URLS.map((url) => new URLPattern(url));
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,6 +15,8 @@ const ALLOWED_URLS = [
 	"https://*.youtube.com",
 	"https://*.googlevideo.com",
 	"https://*.googleapis.com",
+	"https://*.googleusercontent.com",
+	"https://*.mzstatic.com",
 ];
 const ALLOWED_URL_PATTERNS = ALLOWED_URLS.map((url) => new URLPattern(url));
 

--- a/src/components/AppPage.vue
+++ b/src/components/AppPage.vue
@@ -19,11 +19,13 @@ import { computed, ref, useTemplateRef, watch } from "vue";
 const {
 	title,
 	backButton,
-	showHeader = true,
+	showPageHeader = true,
+	showContentHeader = true,
 } = defineProps<{
 	title?: string;
 	backButton?: string;
-	showHeader?: boolean;
+	showPageHeader?: boolean;
+	showContentHeader?: boolean;
 }>();
 
 const slots = defineSlots<{
@@ -65,7 +67,7 @@ watch(bounding.height, (height) => {
 <template>
 	<ion-page id="app-page" :style="{ '--header-height': `${headerHeight}px` }">
 		<Transition name="slide">
-			<ion-header v-if="showHeader" translucent>
+			<ion-header v-if="showPageHeader" translucent>
 				<slot name="header-leading" />
 
 				<slot name="toolbar">
@@ -98,7 +100,7 @@ watch(bounding.height, (height) => {
 
 		<ion-content fullscreen>
 			<Transition name="slide">
-				<ion-header ref="header" v-if="showHeader && title" collapse="condense">
+				<ion-header ref="header" v-if="showContentHeader && title" collapse="condense">
 					<slot name="header-leading" />
 
 					<slot name="toolbar">

--- a/src/components/AppSettingsModal.vue
+++ b/src/components/AppSettingsModal.vue
@@ -32,11 +32,14 @@
 					/>
 				</ion-buttons>
 			</ion-item>
+
+			<ion-item button @click="clearCache">CLEAR CACHE</ion-item>
 		</ion-list>
 	</ion-content>
 </template>
 
 <script lang="ts">
+import { clearCache } from "@/services/Music/objects";
 import { songTypeToDisplayName } from "@/utils/songs";
 import AppSettingsModal from "./AppSettingsModal.vue";
 

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -3,6 +3,7 @@ import { Haptics, ImpactStyle } from "@capacitor/haptics";
 import { IonList } from "@ionic/vue";
 import { onLongPress } from "@vueuse/core";
 import { nextTick, ref, useTemplateRef } from "vue";
+import { onBeforeRouteLeave } from "vue-router";
 
 const _slots = defineSlots<{
 	default(): any;
@@ -93,10 +94,11 @@ function close(): void {
 	emit("visibilitychange", false);
 }
 
-function closeImmediately(): void {
+onBeforeRouteLeave(() => {
+	if (!opened.value) return;
 	opened.value = false;
 	emit("visibilitychange", false);
-}
+});
 </script>
 
 <template>
@@ -111,10 +113,10 @@ function closeImmediately(): void {
 			open
 		>
 			<div class="backdrop" @click.self="close" />
-			<div class="context-menu-item" @click="move ? closeImmediately : close">
+			<div class="context-menu-item" @click="close">
 				<slot />
 			</div>
-			<ion-list ref="contextMenuOptions" inset class="context-menu-list" @click="closeImmediately">
+			<ion-list ref="contextMenuOptions" inset class="context-menu-list" @click="close">
 				<slot name="options" />
 			</ion-list>
 		</div>
@@ -230,7 +232,7 @@ function closeImmediately(): void {
 	transition: var(--context-menu-transition);
 
 	--context-menu-top: clamp(
-		calc(var(--ion-safe-area-top) + 64px),
+		calc(var(--ion-safe-area-top) + 32px),
 		calc(var(--context-menu-item-top) - 64px),
 		calc(90vh - 64px - var(--context-menu-item-height) - var(--context-menu-options-height))
 	);
@@ -310,10 +312,11 @@ function closeImmediately(): void {
 		animation: list-in var(--context-menu-transition-duration) var(--context-menu-transition-easing);
 
 		background-color: transparent;
+		backdrop-filter: blur(6px) saturate(200%);
 
 		& > ion-item {
 			opacity: 90%;
-			backdrop-filter: blur(2px);
+
 			--background: var(--ion-background-color-step-150, #eee);
 			&:hover,
 			&:focus {
@@ -326,6 +329,7 @@ function closeImmediately(): void {
 		}
 
 		& > ion-item-divider {
+			opacity: 90%;
 			min-height: 6px;
 			--background: var(--ion-background-color-step-200, #ccc);
 			outline: 0.02px solid var(--ion-background-color-step-200);

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -1,9 +1,8 @@
 <script lang="ts" setup>
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
-import { IonList } from "@ionic/vue";
+import { IonList, onIonViewWillLeave } from "@ionic/vue";
 import { onLongPress } from "@vueuse/core";
 import { nextTick, ref, useTemplateRef } from "vue";
-import { onBeforeRouteLeave } from "vue-router";
 
 const _slots = defineSlots<{
 	default(): any;
@@ -94,7 +93,7 @@ function close(): void {
 	emit("visibilitychange", false);
 }
 
-onBeforeRouteLeave(() => {
+onIonViewWillLeave(() => {
 	if (!opened.value) return;
 	opened.value = false;
 	emit("visibilitychange", false);

--- a/src/components/ContextMenu.vue
+++ b/src/components/ContextMenu.vue
@@ -18,11 +18,13 @@ const {
 	move = true,
 	backdrop = true,
 	haptics = true,
+	disabled = false,
 	x = "left",
 	y = "top",
 } = defineProps<{
 	event?: "click" | "contextmenu";
 	move?: boolean;
+	disabled?: boolean;
 	backdrop?: boolean;
 	haptics?: boolean;
 	x?: "left" | "center" | "right" | (string & {});
@@ -51,7 +53,7 @@ const options = useTemplateRef("contextMenuOptions");
 const style = ref<Record<string, string>>({});
 
 async function open(): Promise<void> {
-	if (opened.value) return;
+	if (disabled || opened.value) return;
 
 	if (haptics) {
 		await Haptics.impact({ style: ImpactStyle.Heavy }).catch(() => {});

--- a/src/components/GenericAlbumCard.vue
+++ b/src/components/GenericAlbumCard.vue
@@ -1,0 +1,139 @@
+<script lang="ts" setup>
+import { computed, ref } from "vue";
+
+import ContextMenu from "@/components/ContextMenu.vue";
+import LocalImg from "@/components/LocalImg.vue";
+import { IonCard, IonCardHeader, IonCardSubtitle, IonCardTitle, IonIcon } from "@ionic/vue";
+import { compass as compassIcon } from "ionicons/icons";
+
+import { Album, filledDisplayableArtist } from "@/services/Music/objects";
+import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
+
+const {
+	title,
+	type,
+	artwork,
+	artists,
+	button = true,
+	disabled,
+	routerLink,
+} = defineProps<
+	Pick<Partial<Album>, "title" | "type" | "artists" | "artwork"> & {
+		button?: boolean;
+		disabled?: boolean;
+		routerLink?: string;
+	}
+>();
+
+const formattedArtists = computed(
+	() => artists && formatArtists(artists?.map(filledDisplayableArtist)),
+);
+const displayName = computed(() => type && songTypeToDisplayName(type));
+
+const emit = defineEmits<{
+	itemClick: [PointerEvent];
+	contextMenuClick: [PointerEvent];
+	visibilitychange: [value: boolean];
+}>();
+
+const contextMenuOpen = ref(false);
+
+function emitClick(event: PointerEvent): void {
+	if (contextMenuOpen.value) {
+		emit("contextMenuClick", event);
+	} else {
+		emit("itemClick", event);
+	}
+}
+</script>
+
+<template>
+	<ContextMenu :class="$props.class" ref="contextMenu" @visibilitychange="contextMenuOpen = $event">
+		<ion-card
+			class="album-card"
+			:router-link
+			:button
+			:disabled
+			:detail="contextMenuOpen"
+			@click="emitClick"
+			:class="$attrs.class"
+		>
+			<LocalImg v-if="artwork" :src="artwork" :alt="`Artwork for album '${title}'`" />
+
+			<ion-card-header>
+				<ion-card-title class="ion-text-nowrap">
+					{{ title }}
+				</ion-card-title>
+				<ion-card-subtitle class="ion-text-nowrap">
+					<span v-if="type">
+						<ion-icon :icon="compassIcon" />
+						{{ displayName }}
+					</span>
+
+					{{ formattedArtists }}
+				</ion-card-subtitle>
+			</ion-card-header>
+		</ion-card>
+
+		<template #options>
+			<slot name="options" />
+		</template>
+	</ContextMenu>
+</template>
+
+<style scoped>
+.context-item-container,
+.context-menu-dummy {
+	display: inline-block;
+}
+
+.context-menu:not(.closed) > .context-menu-item > .album-card {
+	background: var(--context-menu-item-background);
+}
+
+.context-menu:not(.closed) > .context-menu-item > ion-card {
+	transition: var(--context-menu-transition);
+
+	--background: var(--context-menu-item-background);
+
+	border-radius: 24px;
+	--border-color: transparent;
+	padding: 12px;
+
+	& > .local-img {
+		border-radius: 12px;
+		border: 1px solid #0002;
+	}
+}
+
+.album-card,
+.skeleton-card {
+	margin: 0;
+	background: transparent;
+	box-shadow: none;
+	border-radius: 0;
+
+	& > .local-img {
+		border-radius: 8px;
+		border: 0.55px solid #0002;
+	}
+
+	& > ion-card-header {
+		padding: 8px;
+
+		& > ion-card-title {
+			font-size: 1rem;
+			font-weight: 550;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
+
+		& > ion-card-subtitle {
+			font-size: 0.75rem;
+			font-weight: 400;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
+	}
+}
+</style>

--- a/src/components/GenericSongItem.vue
+++ b/src/components/GenericSongItem.vue
@@ -6,7 +6,7 @@ import LocalImg from "@/components/LocalImg.vue";
 import { IonIcon, IonItem, IonLabel, IonNote, IonReorder } from "@ionic/vue";
 import { compass as compassIcon, musicalNote as musicalNoteIcon } from "ionicons/icons";
 
-import { filledArtistPreview, Song } from "@/services/Music/objects";
+import { filledDisplayableArtist, Song } from "@/services/Music/objects";
 import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
 
 const {
@@ -27,7 +27,7 @@ const {
 	}
 >();
 
-const formattedArtists = computed(() => formatArtists(artists?.map(filledArtistPreview)));
+const formattedArtists = computed(() => formatArtists(artists?.map(filledDisplayableArtist)));
 const displayName = computed(() => songTypeToDisplayName(type));
 
 const emit = defineEmits<{

--- a/src/components/GenericSongItem.vue
+++ b/src/components/GenericSongItem.vue
@@ -6,7 +6,6 @@ import LocalImg from "@/components/LocalImg.vue";
 import { IonIcon, IonItem, IonLabel, IonNote, IonReorder } from "@ionic/vue";
 import { compass as compassIcon, musicalNote as musicalNoteIcon } from "ionicons/icons";
 
-import { LocalImage } from "@/stores/local-images";
 import { AnySong } from "@/stores/music-player";
 import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
 
@@ -19,16 +18,14 @@ const {
 	reorder,
 	disabled,
 	routerLink,
-} = defineProps<{
-	title?: string;
-	type: AnySong["type"];
-	artists: string[];
-	artwork?: LocalImage;
-	reorder?: boolean;
-	button?: boolean;
-	disabled?: boolean;
-	routerLink?: string;
-}>();
+} = defineProps<
+	Partial<AnySong> & {
+		reorder?: boolean;
+		button?: boolean;
+		disabled?: boolean;
+		routerLink?: string;
+	}
+>();
 
 const formattedArtists = computed(() => formatArtists(artists));
 const displayName = computed(() => songTypeToDisplayName(type));

--- a/src/components/GenericSongItem.vue
+++ b/src/components/GenericSongItem.vue
@@ -8,18 +8,21 @@ import { compass as compassIcon, musicalNote as musicalNoteIcon } from "ionicons
 
 import { filledDisplayableArtist, Song } from "@/services/Music/objects";
 import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
+import { secondsToMMSS } from "@/utils/time";
 
 const {
 	button = true,
 	title,
 	type,
 	artists,
+	album,
 	artwork,
+	duration,
 	reorder,
 	disabled,
 	routerLink,
 } = defineProps<
-	Partial<Song> & {
+	Pick<Partial<Song>, "type" | "duration" | "album" | "artists" | "artwork" | "title"> & {
 		reorder?: boolean;
 		button?: boolean;
 		disabled?: boolean;
@@ -27,8 +30,11 @@ const {
 	}
 >();
 
-const formattedArtists = computed(() => formatArtists(artists?.map(filledDisplayableArtist)));
-const displayName = computed(() => songTypeToDisplayName(type));
+const formattedArtists = computed(
+	() => artists && formatArtists(artists?.map(filledDisplayableArtist)),
+);
+const displayName = computed(() => type && songTypeToDisplayName(type));
+const formattedDuration = computed(() => duration && secondsToMMSS(duration));
 
 const emit = defineEmits<{
 	itemClick: [PointerEvent];
@@ -67,14 +73,22 @@ function emitClick(event: PointerEvent): void {
 			<ion-label>
 				<h1>{{ title ?? "Unknown title" }}</h1>
 				<ion-note>
-					<p>
-						<ion-icon :icon="compassIcon" />
-						{{ displayName }}
-					</p>
-					<p>
-						<ion-icon :icon="musicalNoteIcon" />
-						{{ formattedArtists }}
-					</p>
+					<template v-if="artists && type">
+						<p>
+							<ion-icon :icon="compassIcon" />
+							{{ displayName }}
+						</p>
+						<p>
+							<ion-icon :icon="musicalNoteIcon" />
+							{{ formattedArtists }}
+						</p>
+					</template>
+					<template v-else-if="album">
+						{{ album }}
+					</template>
+					<template v-else-if="duration">
+						{{ formattedDuration }}
+					</template>
 				</ion-note>
 			</ion-label>
 
@@ -152,6 +166,8 @@ ion-item {
 		--img-border-radius: 8px;
 		--img-width: auto;
 		--img-height: 56px;
+
+		border: 0.55px solid #0002;
 	}
 
 	& > ion-label {

--- a/src/components/GenericSongItem.vue
+++ b/src/components/GenericSongItem.vue
@@ -101,7 +101,7 @@ function emitClick(event: PointerEvent): void {
 	--padding-start: 12px;
 	--padding-end: 12px;
 
-	& > .song-img {
+	& > .local-img {
 		transition: var(--context-menu-transition);
 
 		--img-border-radius: 12px;
@@ -146,7 +146,7 @@ function emitClick(event: PointerEvent): void {
 }
 
 ion-item {
-	& > .song-img {
+	& > .local-img {
 		pointer-events: none;
 
 		--img-border-radius: 8px;

--- a/src/components/GenericSongItem.vue
+++ b/src/components/GenericSongItem.vue
@@ -6,7 +6,7 @@ import LocalImg from "@/components/LocalImg.vue";
 import { IonIcon, IonItem, IonLabel, IonNote, IonReorder } from "@ionic/vue";
 import { compass as compassIcon, musicalNote as musicalNoteIcon } from "ionicons/icons";
 
-import { AnySong } from "@/stores/music-player";
+import { filledArtistPreview, Song } from "@/services/Music/objects";
 import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
 
 const {
@@ -19,7 +19,7 @@ const {
 	disabled,
 	routerLink,
 } = defineProps<
-	Partial<AnySong> & {
+	Partial<Song> & {
 		reorder?: boolean;
 		button?: boolean;
 		disabled?: boolean;
@@ -27,7 +27,7 @@ const {
 	}
 >();
 
-const formattedArtists = computed(() => formatArtists(artists));
+const formattedArtists = computed(() => formatArtists(artists?.map(filledArtistPreview)));
 const displayName = computed(() => songTypeToDisplayName(type));
 
 const emit = defineEmits<{

--- a/src/components/LocalImagePicker.vue
+++ b/src/components/LocalImagePicker.vue
@@ -36,18 +36,18 @@ async function changeArtwork(): Promise<void> {
 </script>
 
 <template>
-	<div class="song-image-picker">
+	<div class="local-image-picker">
 		<LocalImg :src="image" :alt="`Image picker preview`" @click="imagePicker?.click()" />
 		<input ref="imagePicker" type="file" accept="image/*" @change="changeArtwork" />
 	</div>
 </template>
 
 <style>
-.song-image-picker {
+.local-image-picker {
 	display: flex;
 	justify-content: center;
 
-	& > .song-img {
+	& > .local-img {
 		--img-height: 192px;
 		--img-width: auto;
 

--- a/src/components/LocalImg.vue
+++ b/src/components/LocalImg.vue
@@ -13,11 +13,11 @@ const url = computed(() => localImages.getUrl(src));
 </script>
 
 <template>
-	<img :src="url" :alt :class="`song-img ${$props.class ?? ''}`" />
+	<img :src="url" :alt :class="`local-img ${$props.class ?? ''}`" />
 </template>
 
 <style>
-.song-img {
+.local-img {
 	position: relative;
 	border-radius: var(--img-border-radius, inherit);
 	width: var(--img-width, auto);

--- a/src/components/MiniMusicPlayer.vue
+++ b/src/components/MiniMusicPlayer.vue
@@ -23,7 +23,7 @@ import LocalImg from "@/components/LocalImg.vue";
 
 import { useMusicPlayer } from "@/stores/music-player";
 
-import { filledArtistPreview } from "@/services/Music/objects";
+import { filledDisplayableArtist } from "@/services/Music/objects";
 import { formatArtists } from "@/utils/songs";
 import { useWillKeyboard } from "@/utils/vue";
 
@@ -36,7 +36,7 @@ const state = musicPlayer.state;
 const { currentSong, playing } = storeToRefs(state);
 
 const formattedArtists = computed(() =>
-	formatArtists(currentSong.value?.artists?.map(filledArtistPreview)),
+	formatArtists(currentSong.value?.artists?.map(filledDisplayableArtist)),
 );
 
 const contextMenuOpen = ref(false);

--- a/src/components/MiniMusicPlayer.vue
+++ b/src/components/MiniMusicPlayer.vue
@@ -49,7 +49,7 @@ async function openModal(): Promise<void> {
 function goToSong(): void {
 	const song = currentSong.value;
 	if (!song) return;
-	router.push(`/library/songs/${song.type}/${song.id}`);
+	router.push(`/items/songs/${song.type}/${song.id}`);
 }
 </script>
 

--- a/src/components/MiniMusicPlayer.vue
+++ b/src/components/MiniMusicPlayer.vue
@@ -23,6 +23,7 @@ import LocalImg from "@/components/LocalImg.vue";
 
 import { useMusicPlayer } from "@/stores/music-player";
 
+import { filledArtistPreview } from "@/services/Music/objects";
 import { formatArtists } from "@/utils/songs";
 import { useWillKeyboard } from "@/utils/vue";
 
@@ -34,7 +35,9 @@ const musicPlayer = useMusicPlayer();
 const state = musicPlayer.state;
 const { currentSong, playing } = storeToRefs(state);
 
-const formattedArtists = computed(() => formatArtists(currentSong.value?.artists));
+const formattedArtists = computed(() =>
+	formatArtists(currentSong.value?.artists?.map(filledArtistPreview)),
+);
 
 const contextMenuOpen = ref(false);
 

--- a/src/components/MiniMusicPlayer.vue
+++ b/src/components/MiniMusicPlayer.vue
@@ -142,7 +142,7 @@ ion-tab-bar {
 	--padding-start: 12px;
 	--padding-end: 12px;
 
-	& > .song-img {
+	& > .local-img {
 		transition: var(--context-menu-transition);
 
 		--img-border-radius: 12px;
@@ -221,7 +221,7 @@ ion-tab-bar {
 		visibility: hidden;
 	}
 
-	& > .song-img {
+	& > .local-img {
 		pointer-events: none;
 
 		--img-border-radius: 8px;

--- a/src/components/MultiValueInput.vue
+++ b/src/components/MultiValueInput.vue
@@ -54,7 +54,9 @@ function handleValueAddition(event: InputCustomEvent): void {
 		event.target.value = "";
 	}
 }
-function handleValueRemoval(): void {
+function handleValueRemoval(event: InputCustomEvent): void {
+	if (event.target.value) return;
+
 	if (markedValue.value) {
 		markedValue.value = undefined;
 		emit("change", [...values]);

--- a/src/components/MusicPlayer.vue
+++ b/src/components/MusicPlayer.vue
@@ -433,12 +433,12 @@ function dismiss(): void {
 		min-height: calc(var(--modal-handle-top) + 80px);
 		max-height: calc(var(--modal-handle-top) + 80px);
 
-		& > .song-img,
+		& > .local-img,
 		& > #song-info {
 			top: calc(var(--modal-handle-top) + 6px);
 		}
 
-		& > .song-img {
+		& > .local-img {
 			position: absolute;
 			z-index: 100;
 			left: 24px;
@@ -530,7 +530,7 @@ function dismiss(): void {
 		flex-direction: column;
 		height: 100%;
 
-		& > .song-img {
+		& > .local-img {
 			justify-self: center;
 			align-self: center;
 			margin-block: auto;

--- a/src/components/MusicPlayer.vue
+++ b/src/components/MusicPlayer.vue
@@ -36,7 +36,7 @@ import {
 
 import { useMusicPlayer } from "@/stores/music-player";
 
-import { filledArtistPreview, Song } from "@/services/Music/objects";
+import { filledDisplayableArtist, Song } from "@/services/Music/objects";
 import { isMobilePlatform } from "@/utils/os";
 import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
 import { secondsToMMSS } from "@/utils/time";
@@ -47,7 +47,7 @@ const state = musicPlayer.state;
 const { currentSong, time, playing, duration } = storeToRefs(state);
 
 const formattedArtists = computed(() =>
-	formatArtists(currentSong.value?.artists?.map(filledArtistPreview)),
+	formatArtists(currentSong.value?.artists?.map(filledDisplayableArtist)),
 );
 const currentTime = computed(() => secondsToMMSS(time.value));
 const timeRemaining = computed(() => secondsToMMSS(musicPlayer.timeRemaining));

--- a/src/components/MusicPlayer.vue
+++ b/src/components/MusicPlayer.vue
@@ -34,8 +34,9 @@ import {
 	playSkipBack as skipPreviousIcon,
 } from "ionicons/icons";
 
-import { AnySong, useMusicPlayer } from "@/stores/music-player";
+import { useMusicPlayer } from "@/stores/music-player";
 
+import { filledArtistPreview, Song } from "@/services/Music/objects";
 import { isMobilePlatform } from "@/utils/os";
 import { formatArtists, songTypeToDisplayName } from "@/utils/songs";
 import { secondsToMMSS } from "@/utils/time";
@@ -45,7 +46,9 @@ const musicPlayer = useMusicPlayer();
 const state = musicPlayer.state;
 const { currentSong, time, playing, duration } = storeToRefs(state);
 
-const formattedArtists = computed(() => formatArtists(currentSong.value?.artists));
+const formattedArtists = computed(() =>
+	formatArtists(currentSong.value?.artists?.map(filledArtistPreview)),
+);
 const currentTime = computed(() => secondsToMMSS(time.value));
 const timeRemaining = computed(() => secondsToMMSS(musicPlayer.timeRemaining));
 const currentService = computed(
@@ -86,7 +89,7 @@ function reorderQueue(event: ItemReorderCustomEvent): void {
 	event.detail.complete();
 }
 
-function goToSong(song: AnySong, hash?: string): void {
+function goToSong(song: Song, hash?: string): void {
 	dismiss();
 	router.push(`/library/songs/${song.type}/${song.id}` + (hash ? `#${hash}` : ""));
 }

--- a/src/components/MusicPlayer.vue
+++ b/src/components/MusicPlayer.vue
@@ -569,7 +569,7 @@ function dismiss(): void {
 					--marquee-duration: 20s;
 					--marquee-gap: 12px;
 
-					.wrapping {
+					& .wrapping {
 						mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
 					}
 
@@ -580,7 +580,7 @@ function dismiss(): void {
 
 				& > h2 {
 					overflow: hidden;
-					.wrapping {
+					& .wrapping {
 						mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
 					}
 

--- a/src/components/MusicPlayer.vue
+++ b/src/components/MusicPlayer.vue
@@ -91,7 +91,7 @@ function reorderQueue(event: ItemReorderCustomEvent): void {
 
 function goToSong(song: Song, hash?: string): void {
 	dismiss();
-	router.push(`/library/songs/${song.type}/${song.id}` + (hash ? `#${hash}` : ""));
+	router.push(`/items/songs/${song.type}/${song.id}` + (hash ? `#${hash}` : ""));
 }
 
 function dismiss(): void {

--- a/src/components/SkeletonCard.vue
+++ b/src/components/SkeletonCard.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+import {
+	IonCard,
+	IonCardHeader,
+	IonCardSubtitle,
+	IonCardTitle,
+	IonSkeletonText,
+	IonThumbnail,
+} from "@ionic/vue";
+
+function randomIntBetween(min: number, max: number): number {
+	return Math.floor(Math.random() * (max - min) + min);
+}
+</script>
+
+<template>
+	<ion-card class="skeleton-card">
+		<ion-thumbnail>
+			<ion-skeleton-text :animated="true" />
+		</ion-thumbnail>
+
+		<ion-card-header>
+			<ion-card-title>
+				<ion-skeleton-text :animated="true" :style="`width: ${randomIntBetween(40, 70)}%`" />
+			</ion-card-title>
+			<ion-card-subtitle>
+				<ion-skeleton-text :animated="true" :style="`width: ${randomIntBetween(20, 30)}%`" />
+			</ion-card-subtitle>
+		</ion-card-header>
+	</ion-card>
+</template>
+
+<style>
+@keyframes show-up {
+	from {
+		opacity: 0%;
+	}
+
+	to {
+		opacity: 100%;
+	}
+}
+
+.skeleton-card {
+	animation: show-up 250ms ease-in;
+
+	& > ion-thumbnail {
+		--border-radius: 12px;
+		width: 100%;
+		height: auto;
+		aspect-ratio: 1 / 1;
+	}
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
 		await import("./mobile");
 	}
 
-	const app = createApp(App).use(IonicVue).use(pinia).use(router);
+	const app = createApp(App).use(IonicVue).use(router).use(pinia);
 
 	await router.isReady().then(() => {
 		app.mount("#app");

--- a/src/pages/App.vue
+++ b/src/pages/App.vue
@@ -50,4 +50,22 @@ ion-tabs:has(~ ion-modal[id^="ion-overlay"]) {
 		height: 100vh;
 	}
 }
+
+@keyframes fade-in {
+	from {
+		opacity: 0%;
+	}
+
+	40% {
+		opacity: 0%;
+	}
+
+	to {
+		opacity: 100%;
+	}
+}
+
+ion-app {
+	animation: fade-in 400ms forwards;
+}
 </style>

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -134,7 +134,7 @@ watchEffect(() => {
 		}
 	}
 
-	& > .song-img {
+	& > .local-img {
 		margin-inline: auto;
 
 		--img-height: 192px;

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -74,9 +74,6 @@ async function playAlbum(shuffle = false): Promise<void> {
 		album.value.songs.map(({ song }) => song),
 	);
 
-	console.log("Album songs:", album.value.songs);
-	console.log("Set songs:", songs);
-
 	musicPlayer.state.setQueue(songs);
 
 	if (shuffle) {
@@ -163,7 +160,7 @@ async function addAlbumToQueue(position: "next" | "last"): Promise<void> {
 						class="artist"
 						role="link"
 						aria-roledescription="Go to artist"
-						:to="`/library/artists/${artist.type}/${artist.id}`"
+						:to="`/items/artists/${artist.type}/${artist.id}`"
 					>
 						{{ artist.title }}
 					</RouterLink>

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -237,7 +237,10 @@ async function addAlbumToQueue(position: "next" | "last"): Promise<void> {
 	animation: fade-in 350ms;
 
 	& > ion-header {
-		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		& .wrapping {
+			mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		}
+
 		width: max-content;
 		max-width: 100%;
 		margin-inline: auto;

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -218,6 +218,7 @@ async function addAlbumToQueue(position: "next" | "last"): Promise<void> {
 	& > ion-header {
 		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
 		width: max-content;
+		max-width: 100%;
 		margin-inline: auto;
 
 		& ion-title {

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -60,7 +60,9 @@ const groupedSongs = computed(() => {
 async function playAlbum(shuffle = false): Promise<void> {
 	if (!album.value) return;
 	const songs = await Promise.all(
-		album.value.songs.map(({ song }) => musicPlayer.services.getSongFromPreview(song)),
+		album.value.songs
+			.filter(({ song }) => song.available)
+			.map(({ song }) => musicPlayer.services.getSongFromPreview(song)),
 	);
 	musicPlayer.state.setQueue(songs);
 
@@ -73,7 +75,9 @@ async function playAlbum(shuffle = false): Promise<void> {
 
 async function playDisc(discSongs: Album["songs"]): Promise<void> {
 	const songs = await Promise.all(
-		discSongs.map(({ song }) => musicPlayer.services.getSongFromPreview(song)),
+		discSongs
+			.filter(({ song }) => song.available)
+			.map(({ song }) => musicPlayer.services.getSongFromPreview(song)),
 	);
 	musicPlayer.state.setQueue(songs);
 	musicPlayer.state.queueIndex = 0;
@@ -285,6 +289,12 @@ async function addAlbumToQueue(position: "next" | "last"): Promise<void> {
 		box-shadow: 0 0 12px var(--shadow-color);
 		margin-block: 24px;
 		background-color: rgba(var(--ion-color-dark-rgb), 0.08);
+	}
+
+	& > ion-list {
+		& > .disc-header {
+			font-weight: 550;
+		}
 	}
 }
 </style>

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -1,0 +1,151 @@
+<script lang="ts" setup>
+import { IonHeader, IonList, IonTitle, IonToolbar } from "@ionic/vue";
+import { computedAsync } from "@vueuse/core";
+import { computed, watchEffect } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import AppPage from "@/components/AppPage.vue";
+import GenericSongItem from "@/components/GenericSongItem.vue";
+import LocalImg from "@/components/LocalImg.vue";
+import WrappingMarquee from "@/components/WrappingMarquee.vue";
+
+import { AnySong, useMusicPlayer } from "@/stores/music-player";
+
+const musicPlayer = useMusicPlayer();
+const router = useRouter();
+const route = useRoute();
+
+const previousRouteName = computed(() => {
+	const { state } = router.options.history;
+	if (!("back" in state)) return "Albums";
+	return String(router.resolve(state.back as any)?.name);
+});
+
+const album = computedAsync(async () => {
+	const { albumType, albumId, songType, songId } = route.params;
+
+	if (songType) {
+		const song = await musicPlayer.services.getSong(songType as AnySong["type"], songId as string);
+		return song && (await musicPlayer.services.getSongsAlbum(song));
+	}
+
+	return await musicPlayer.services.getAlbum(albumType as AnySong["type"], albumId as string);
+});
+
+watchEffect(() => {
+	console.log(album.value);
+});
+</script>
+
+<template>
+	<AppPage :title="album?.title" :show-content-header="false" :back-button="previousRouteName">
+		<div id="album-content" v-if="album">
+			<LocalImg :src="album.artwork" />
+
+			<ion-header collapse="condense">
+				<ion-toolbar>
+					<ion-title class="ion-text-nowrap" size="large">
+						<WrappingMarquee :text="album.title" />
+					</ion-title>
+				</ion-toolbar>
+			</ion-header>
+
+			<h2>
+				<a
+					class="artist"
+					role="link"
+					aria-roledescription="Go to artist"
+					v-for="artist in album.artists"
+					:key="artist.id"
+				>
+					{{ artist.name }}
+				</a>
+			</h2>
+
+			<ion-list>
+				<GenericSongItem
+					v-for="song in album.songs"
+					:key="song.id"
+					:title="song.title"
+					:artists="song.artists"
+					:artwork="song.artwork"
+					:type="song.type"
+				>
+					<template #options></template>
+				</GenericSongItem>
+			</ion-list>
+		</div>
+	</AppPage>
+</template>
+
+<style scoped>
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+#album-content {
+	text-align: center;
+
+	animation: fade-in 350ms;
+
+	& > ion-header {
+		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+
+		& ion-title {
+			transform-origin: top center;
+			justify-content: center;
+
+			font-weight: 550;
+			margin: 0;
+
+			--marquee-duration: 20s;
+			--marquee-align: center;
+		}
+	}
+
+	& > h2 {
+		font-size: 1.25rem;
+		font-weight: 550;
+
+		margin-top: 0;
+		margin-inline: auto;
+
+		& > a {
+			cursor: pointer;
+			color: var(--ion-color-dark-rgb);
+
+			&:hover {
+				opacity: 80%;
+
+				@media (pointer: fine) {
+					text-decoration: underline;
+				}
+			}
+
+			&:active {
+				opacity: 60%;
+			}
+		}
+	}
+
+	& > .song-img {
+		margin-inline: auto;
+
+		--img-height: 192px;
+		--img-width: auto;
+
+		--shadow-color: rgba(var(--ion-color-dark-rgb), 0.1);
+
+		border-radius: 12px;
+		box-shadow: 0 0 12px var(--shadow-color);
+		margin-block: 24px;
+		background-color: rgba(var(--ion-color-dark-rgb), 0.08);
+	}
+}
+</style>

--- a/src/pages/Library/Albums/Album/AlbumPage.vue
+++ b/src/pages/Library/Albums/Album/AlbumPage.vue
@@ -160,8 +160,8 @@ async function addAlbumToQueue(position: "next" | "last"): Promise<void> {
 					class="artist"
 					role="link"
 					aria-roledescription="Go to artist"
-					v-for="artist in album.artists"
-					:key="artist.id"
+					v-for="(artist, i) in album.artists"
+					:key="'id' in artist ? artist.id : i"
 				>
 					{{ artist.title }}
 				</a>

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -29,14 +29,14 @@ onUpdated(async () => {
 		for await (const album of musicPlayer.services.libraryAlbums()) {
 			libraryAlbums.value.push(album);
 		}
-		console.log("LAB:", libraryAlbums.value.length);
 		isLoading.value = false;
 	}
 });
 
 async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
-	await musicPlayer.services.refreshLibraryAlbums();
 	isLoading.value = true;
+	await musicPlayer.services.refreshLibraryAlbums();
+	libraryAlbums.value.length = 0;
 	for await (const album of musicPlayer.services.libraryAlbums()) {
 		libraryAlbums.value.push(album);
 	}

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -48,7 +48,7 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 		<div v-else class="album-cards">
 			<GenericAlbumCard
 				class="album-card"
-				:router-link="`/library/albums/album/${album.type}/${album.id}`"
+				:router-link="`/items/albums/album/${album.type}/${album.id}`"
 				v-for="album in libraryAlbums"
 				:key="album.id"
 				:artwork="album.artwork"

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -51,11 +51,11 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 			<ion-refresher-content />
 		</ion-refresher>
 
-		<div class="album-cards">
-			<template v-if="isLoading">
-				<SkeletonCard v-for="i in 25" :key="i" />
-			</template>
-			<ContextMenu v-else v-for="album in libraryAlbums" :key="album.id">
+		<div v-if="isLoading" class="album-cards">
+			<SkeletonCard v-for="i in 25" :key="i" />
+		</div>
+		<div v-else class="album-cards">
+			<ContextMenu v-for="album in libraryAlbums" :key="album.id">
 				<ion-card class="album-card" :router-link="`/library/albums/album/${album.type}/${album.id}`">
 					<LocalImg :src="album.artwork" />
 
@@ -74,6 +74,16 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 </template>
 
 <style scoped>
+@keyframes show-up {
+	from {
+		opacity: 0%;
+	}
+
+	to {
+		opacity: 100%;
+	}
+}
+
 .album-cards {
 	display: grid;
 	width: 100vw;
@@ -82,6 +92,8 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 
 	justify-content: center;
 	align-items: center;
+
+	animation: show-up 250ms ease-in;
 
 	--gap: 8px;
 	--columns: 1;
@@ -126,24 +138,12 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 	background: var(--context-menu-item-background);
 }
 
-@keyframes show-up {
-	from {
-		opacity: 0%;
-	}
-
-	to {
-		opacity: 100%;
-	}
-}
-
 .album-card,
 .skeleton-card {
 	margin: 0;
 	background: transparent;
 	box-shadow: none;
 	border-radius: 0;
-
-	animation: show-up 250ms ease-in;
 
 	& > .local-img {
 		border-radius: 8px;

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -15,14 +15,14 @@ import LocalImg from "@/components/LocalImg.vue";
 
 import ContextMenu from "@/components/ContextMenu.vue";
 import SkeletonCard from "@/components/SkeletonCard.vue";
-import { AlbumPreview, filledArtistPreview } from "@/services/Music/objects";
+import { Album, AlbumPreview, filledDisplayableArtist } from "@/services/Music/objects";
 import { useMusicPlayer } from "@/stores/music-player";
 import { formatArtists } from "@/utils/songs";
 import { useSessionStorage } from "@vueuse/core";
 
 const musicPlayer = useMusicPlayer();
 
-const libraryAlbums = useSessionStorage<AlbumPreview[]>("libraryAlbums", []);
+const libraryAlbums = useSessionStorage<(Album | AlbumPreview)[]>("libraryAlbums", []);
 const isLoading = ref(libraryAlbums.value.length === 0);
 onUpdated(async () => {
 	if (!libraryAlbums.value.length) {
@@ -65,7 +65,7 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 							{{ album.title }}
 						</ion-card-title>
 						<ion-card-subtitle class="ion-text-nowrap">
-							{{ formatArtists(album.artists.map(filledArtistPreview)) }}
+							{{ formatArtists(album.artists.map(filledDisplayableArtist)) }}
 						</ion-card-subtitle>
 					</ion-card-header>
 				</ion-card>

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -1,23 +1,13 @@
 <script lang="ts" setup>
-import {
-	IonCard,
-	IonCardHeader,
-	IonCardSubtitle,
-	IonCardTitle,
-	IonRefresher,
-	IonRefresherContent,
-	RefresherCustomEvent,
-} from "@ionic/vue";
+import { IonRefresher, IonRefresherContent, RefresherCustomEvent } from "@ionic/vue";
 import { onUpdated, ref } from "vue";
 
 import AppPage from "@/components/AppPage.vue";
-import LocalImg from "@/components/LocalImg.vue";
 
-import ContextMenu from "@/components/ContextMenu.vue";
+import GenericAlbumCard from "@/components/GenericAlbumCard.vue";
 import SkeletonCard from "@/components/SkeletonCard.vue";
-import { Album, AlbumPreview, filledDisplayableArtist } from "@/services/Music/objects";
+import { Album, AlbumPreview } from "@/services/Music/objects";
 import { useMusicPlayer } from "@/stores/music-player";
-import { formatArtists } from "@/utils/songs";
 import { useSessionStorage } from "@vueuse/core";
 
 const musicPlayer = useMusicPlayer();
@@ -56,20 +46,15 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 			<SkeletonCard v-for="i in 25" :key="i" />
 		</div>
 		<div v-else class="album-cards">
-			<ContextMenu v-for="album in libraryAlbums" :key="album.id">
-				<ion-card class="album-card" :router-link="`/library/albums/album/${album.type}/${album.id}`">
-					<LocalImg :src="album.artwork" />
-
-					<ion-card-header>
-						<ion-card-title class="ion-text-nowrap">
-							{{ album.title }}
-						</ion-card-title>
-						<ion-card-subtitle class="ion-text-nowrap">
-							{{ formatArtists(album.artists.map(filledDisplayableArtist)) }}
-						</ion-card-subtitle>
-					</ion-card-header>
-				</ion-card>
-			</ContextMenu>
+			<GenericAlbumCard
+				class="album-card"
+				:router-link="`/library/albums/album/${album.type}/${album.id}`"
+				v-for="album in libraryAlbums"
+				:key="album.id"
+				:artwork="album.artwork"
+				:title="album.title"
+				:artists="album.artists"
+			/>
 		</div>
 	</AppPage>
 </template>
@@ -114,32 +99,8 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 	}
 	gap: var(--gap);
 	grid-template-columns: repeat(var(--columns), calc(100% / var(--columns) - var(--gap)));
-
-	.context-menu:not(.closed) > .context-menu-item > ion-card {
-		transition: var(--context-menu-transition);
-
-		--background: var(--context-menu-item-background);
-
-		border-radius: 24px;
-		--border-color: transparent;
-		padding: 12px;
-
-		& > .local-img {
-			border-radius: 12px;
-		}
-	}
-
-	& .context-item-container,
-	:global(& .context-menu-dummy) {
-		display: inline-block;
-	}
 }
 
-.context-menu:not(.closed) > .context-menu-item > .album-card {
-	background: var(--context-menu-item-background);
-}
-
-.album-card,
 .skeleton-card {
 	margin: 0;
 	background: transparent;

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -1,9 +1,170 @@
+<script lang="ts" setup>
+import {
+	IonCard,
+	IonCardHeader,
+	IonCardSubtitle,
+	IonCardTitle,
+	IonRefresher,
+	IonRefresherContent,
+	RefresherCustomEvent,
+} from "@ionic/vue";
+import { onUpdated, ref } from "vue";
+
+import AppPage from "@/components/AppPage.vue";
+import LocalImg from "@/components/LocalImg.vue";
+
+import ContextMenu from "@/components/ContextMenu.vue";
+import SkeletonCard from "@/components/SkeletonCard.vue";
+import { AlbumPreview, useMusicPlayer } from "@/stores/music-player";
+import { formatArtists } from "@/utils/songs";
+import { useSessionStorage } from "@vueuse/core";
+
+const musicPlayer = useMusicPlayer();
+
+const libraryAlbums = useSessionStorage<AlbumPreview[]>("libraryAlbums", []);
+const isLoading = ref(libraryAlbums.value.length === 0);
+onUpdated(async () => {
+	if (!libraryAlbums.value.length) {
+		isLoading.value = true;
+		for await (const album of musicPlayer.services.libraryAlbums()) {
+			libraryAlbums.value.push(album);
+		}
+		console.log("LAB:", libraryAlbums.value.length);
+		isLoading.value = false;
+	}
+});
+
+async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
+	await musicPlayer.services.refreshLibraryAlbums();
+	isLoading.value = true;
+	for await (const album of musicPlayer.services.libraryAlbums()) {
+		libraryAlbums.value.push(album);
+	}
+	isLoading.value = false;
+	await event.target.complete();
+}
+</script>
+
 <template>
 	<AppPage title="Albums" back-button="Library">
-		<!-- TODO -->
+		<ion-refresher slot="fixed" @ion-refresh="refreshAlbumLibrary">
+			<ion-refresher-content />
+		</ion-refresher>
+
+		<div class="album-cards">
+			<template v-if="isLoading">
+				<SkeletonCard v-for="i in 25" :key="i" />
+			</template>
+			<ContextMenu v-else v-for="album in libraryAlbums" :key="album.id">
+				<ion-card class="album-card" :router-link="`/library/albums/album/${album.type}/${album.id}`">
+					<LocalImg :src="album.artwork" />
+
+					<ion-card-header>
+						<ion-card-title class="ion-text-nowrap">
+							{{ album.title }}
+						</ion-card-title>
+						<ion-card-subtitle class="ion-text-nowrap">
+							{{ formatArtists(album.artists.map(({ name }) => name)) }}
+						</ion-card-subtitle>
+					</ion-card-header>
+				</ion-card>
+			</ContextMenu>
+		</div>
 	</AppPage>
 </template>
 
-<script lang="ts" setup>
-import AppPage from "@/components/AppPage.vue";
-</script>
+<style scoped>
+.album-cards {
+	display: grid;
+	width: 100vw;
+	padding: 8px;
+	grid-template-rows: auto;
+
+	justify-content: center;
+	align-items: center;
+
+	--gap: 8px;
+	--columns: 1;
+	@media screen and (min-width: 320px) {
+		--columns: 2;
+	}
+	@media screen and (min-width: 640px) {
+		--gap: 16px;
+		--columns: 3;
+	}
+	@media screen and (min-width: 960px) {
+		--columns: 4;
+	}
+	@media screen and (min-width: 960px) {
+		--gap: 24px;
+		--columns: 4;
+	}
+	gap: var(--gap);
+	grid-template-columns: repeat(var(--columns), calc(100% / var(--columns) - var(--gap)));
+
+	.context-menu:not(.closed) > .context-menu-item > ion-card {
+		transition: var(--context-menu-transition);
+
+		--background: var(--context-menu-item-background);
+
+		border-radius: 24px;
+		--border-color: transparent;
+		padding: 12px;
+
+		& > .local-img {
+			border-radius: 12px;
+		}
+	}
+
+	& .context-item-container,
+	:global(& .context-menu-dummy) {
+		display: inline-block;
+	}
+}
+
+.context-menu:not(.closed) > .context-menu-item > .album-card {
+	background: var(--context-menu-item-background);
+}
+
+@keyframes show-up {
+	from {
+		opacity: 0%;
+	}
+
+	to {
+		opacity: 100%;
+	}
+}
+
+.album-card,
+.skeleton-card {
+	margin: 0;
+	background: transparent;
+	box-shadow: none;
+	border-radius: 0;
+
+	animation: show-up 250ms ease-in;
+
+	& > .local-img {
+		border-radius: 8px;
+	}
+
+	& > ion-card-header {
+		padding: 8px;
+
+		& > ion-card-title {
+			font-size: 1rem;
+			font-weight: 550;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
+
+		& > ion-card-subtitle {
+			font-size: 0.75rem;
+			font-weight: 400;
+			text-overflow: ellipsis;
+			overflow: hidden;
+		}
+	}
+}
+</style>

--- a/src/pages/Library/Albums/AlbumsPage.vue
+++ b/src/pages/Library/Albums/AlbumsPage.vue
@@ -15,7 +15,8 @@ import LocalImg from "@/components/LocalImg.vue";
 
 import ContextMenu from "@/components/ContextMenu.vue";
 import SkeletonCard from "@/components/SkeletonCard.vue";
-import { AlbumPreview, useMusicPlayer } from "@/stores/music-player";
+import { AlbumPreview, filledArtistPreview } from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
 import { formatArtists } from "@/utils/songs";
 import { useSessionStorage } from "@vueuse/core";
 
@@ -64,7 +65,7 @@ async function refreshAlbumLibrary(event: RefresherCustomEvent): Promise<void> {
 							{{ album.title }}
 						</ion-card-title>
 						<ion-card-subtitle class="ion-text-nowrap">
-							{{ formatArtists(album.artists.map(({ name }) => name)) }}
+							{{ formatArtists(album.artists.map(filledArtistPreview)) }}
 						</ion-card-subtitle>
 					</ion-card-header>
 				</ion-card>

--- a/src/pages/Library/Albums/components/AlbumDiscSong.vue
+++ b/src/pages/Library/Albums/components/AlbumDiscSong.vue
@@ -1,10 +1,13 @@
 <script lang="ts" setup>
+import { ref } from "vue";
+
 import { Album, DiscSong, useMusicPlayer } from "@/stores/music-player";
+
+import { IonBadge, IonIcon, IonItem, IonLabel, useIonRouter } from "@ionic/vue";
+import { alert as alertIcon } from "ionicons/icons";
 
 import ContextMenu from "@/components/ContextMenu.vue";
 import LocalImg from "@/components/LocalImg.vue";
-import { IonBadge, IonItem, IonLabel, useIonRouter } from "@ionic/vue";
-import { ref } from "vue";
 
 const { discSong, album } = defineProps<{
 	discSong: DiscSong;
@@ -32,9 +35,16 @@ async function playDiscSong(): Promise<void> {
 </script>
 
 <template>
-	<ContextMenu ref="contextMenu" @visibilitychange="contextMenuOpen = $event">
-		<ion-item button lines="full" @click="click">
-			<ion-badge color="light" slot="start">{{ discSong.trackNumber ?? "?" }}</ion-badge>
+	<ContextMenu
+		:disabled="!discSong.song.available"
+		ref="contextMenu"
+		@visibilitychange="contextMenuOpen = $event"
+	>
+		<ion-item :disabled="!discSong.song.available" button lines="full" @click="click">
+			<ion-badge color="light" slot="start">
+				{{ discSong.trackNumber ?? "!" }}
+			</ion-badge>
+
 			<LocalImg
 				v-if="album.artwork"
 				slot="start"

--- a/src/pages/Library/Albums/components/AlbumDiscSong.vue
+++ b/src/pages/Library/Albums/components/AlbumDiscSong.vue
@@ -21,7 +21,7 @@ const contextMenuOpen = ref(false);
 
 async function click(): Promise<void> {
 	if (contextMenuOpen.value) {
-		router.push(`/library/songs/${albumSong.song.type}/${albumSong.song.id}`);
+		router.push(`/items/songs/${albumSong.song.type}/${albumSong.song.id}`);
 	} else {
 		await playAlbumSong();
 	}
@@ -29,8 +29,7 @@ async function click(): Promise<void> {
 
 async function playAlbumSong(): Promise<void> {
 	const song = await musicPlayer.services.retrieveSong(albumSong.song);
-	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex + 1);
-	musicPlayer.state.queueIndex = musicPlayer.state.queueIndex + 1;
+	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex);
 }
 </script>
 

--- a/src/pages/Library/Albums/components/AlbumDiscSong.vue
+++ b/src/pages/Library/Albums/components/AlbumDiscSong.vue
@@ -1,16 +1,17 @@
 <script lang="ts" setup>
 import { ref } from "vue";
 
-import { Album, DiscSong, useMusicPlayer } from "@/stores/music-player";
+import { useMusicPlayer } from "@/stores/music-player";
 
 import { IonBadge, IonItem, IonLabel, useIonRouter } from "@ionic/vue";
 
 import ContextMenu from "@/components/ContextMenu.vue";
 import LocalImg from "@/components/LocalImg.vue";
+import { Album, AlbumSong, Filled } from "@/services/Music/objects";
 
-const { discSong, album } = defineProps<{
-	discSong: DiscSong;
-	album: Album;
+const { albumSong, album } = defineProps<{
+	albumSong: Filled<AlbumSong>;
+	album: Filled<Album>;
 }>();
 
 const musicPlayer = useMusicPlayer();
@@ -20,14 +21,14 @@ const contextMenuOpen = ref(false);
 
 async function click(): Promise<void> {
 	if (contextMenuOpen.value) {
-		router.push(`/library/songs/${discSong.song.type}/${discSong.song.id}`);
+		router.push(`/library/songs/${albumSong.song.type}/${albumSong.song.id}`);
 	} else {
-		await playDiscSong();
+		await playAlbumSong();
 	}
 }
 
-async function playDiscSong(): Promise<void> {
-	const song = await musicPlayer.services.getSongFromPreview(discSong.song);
+async function playAlbumSong(): Promise<void> {
+	const song = await musicPlayer.services.retrieveSong(albumSong.song);
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex + 1);
 	musicPlayer.state.queueIndex = musicPlayer.state.queueIndex + 1;
 }
@@ -35,23 +36,23 @@ async function playDiscSong(): Promise<void> {
 
 <template>
 	<ContextMenu
-		:disabled="!discSong.song.available"
+		:disabled="!albumSong.song.available"
 		ref="contextMenu"
 		@visibilitychange="contextMenuOpen = $event"
 	>
-		<ion-item :disabled="!discSong.song.available" button lines="full" @click="click">
+		<ion-item :disabled="!albumSong.song.available" button lines="full" @click="click">
 			<ion-badge color="light" slot="start">
-				{{ discSong.trackNumber ?? "!" }}
+				{{ albumSong.trackNumber ?? "!" }}
 			</ion-badge>
 
 			<LocalImg
 				v-if="album.artwork"
 				slot="start"
 				:src="album.artwork"
-				:alt="`Artwork for song '${discSong.song.title}' from album '${album.title}'`"
+				:alt="`Artwork for song '${albumSong.song.title}' from album '${album.title}'`"
 			/>
 
-			<ion-label>{{ discSong.song.title ?? "Unknown title" }}</ion-label>
+			<ion-label>{{ albumSong.song.title ?? "Unknown title" }}</ion-label>
 		</ion-item>
 
 		<template #options>

--- a/src/pages/Library/Albums/components/AlbumDiscSong.vue
+++ b/src/pages/Library/Albums/components/AlbumDiscSong.vue
@@ -3,8 +3,7 @@ import { ref } from "vue";
 
 import { Album, DiscSong, useMusicPlayer } from "@/stores/music-player";
 
-import { IonBadge, IonIcon, IonItem, IonLabel, useIonRouter } from "@ionic/vue";
-import { alert as alertIcon } from "ionicons/icons";
+import { IonBadge, IonItem, IonLabel, useIonRouter } from "@ionic/vue";
 
 import ContextMenu from "@/components/ContextMenu.vue";
 import LocalImg from "@/components/LocalImg.vue";
@@ -19,7 +18,7 @@ const router = useIonRouter();
 
 const contextMenuOpen = ref(false);
 
-async function click() {
+async function click(): Promise<void> {
 	if (contextMenuOpen.value) {
 		router.push(`/library/songs/${discSong.song.type}/${discSong.song.id}`);
 	} else {

--- a/src/pages/Library/Albums/components/AlbumDiscSong.vue
+++ b/src/pages/Library/Albums/components/AlbumDiscSong.vue
@@ -1,0 +1,98 @@
+<script lang="ts" setup>
+import { Album, DiscSong, useMusicPlayer } from "@/stores/music-player";
+
+import ContextMenu from "@/components/ContextMenu.vue";
+import LocalImg from "@/components/LocalImg.vue";
+import { IonBadge, IonItem, IonLabel, useIonRouter } from "@ionic/vue";
+import { ref } from "vue";
+
+const { discSong, album } = defineProps<{
+	discSong: DiscSong;
+	album: Album;
+}>();
+
+const musicPlayer = useMusicPlayer();
+const router = useIonRouter();
+
+const contextMenuOpen = ref(false);
+
+async function click() {
+	if (contextMenuOpen.value) {
+		router.push(`/library/songs/${discSong.song.type}/${discSong.song.id}`);
+	} else {
+		await playDiscSong();
+	}
+}
+
+async function playDiscSong(): Promise<void> {
+	const song = await musicPlayer.services.getSongFromPreview(discSong.song);
+	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex + 1);
+	musicPlayer.state.queueIndex = musicPlayer.state.queueIndex + 1;
+}
+</script>
+
+<template>
+	<ContextMenu ref="contextMenu" @visibilitychange="contextMenuOpen = $event">
+		<ion-item button lines="full" @click="click">
+			<ion-badge color="light" slot="start">{{ discSong.trackNumber ?? "?" }}</ion-badge>
+			<LocalImg
+				v-if="album.artwork"
+				slot="start"
+				:src="album.artwork"
+				:alt="`Artwork for song '${discSong.song.title}' from album '${album.title}'`"
+			/>
+
+			<ion-label>{{ discSong.song.title ?? "Unknown title" }}</ion-label>
+		</ion-item>
+
+		<template #options>
+			<slot name="options" />
+		</template>
+	</ContextMenu>
+</template>
+
+<style scoped>
+& .context-menu:not(.closed) > .context-menu-item > ion-item {
+	transition: var(--context-menu-transition);
+
+	--background: var(--context-menu-item-background);
+
+	border-radius: 24px;
+	--border-color: transparent;
+
+	--padding-top: 12px;
+	--padding-bottom: 12px;
+	--padding-start: 12px;
+	--padding-end: 12px;
+
+	& > ion-badge {
+		display: none;
+	}
+
+	& > .local-img {
+		display: block;
+	}
+
+	& > ion-label {
+		white-space: normal;
+		font-weight: 550;
+		font-size: 1.2rem;
+	}
+}
+
+& ion-item {
+	&.disc-header {
+		font-size: 1.25rem;
+		font-weight: 550;
+	}
+
+	& > .local-img {
+		display: none;
+		transition: var(--context-menu-transition);
+
+		--img-border-radius: 12px;
+		--img-width: 96px;
+		--img-height: auto;
+	}
+}
+</style>

--- a/src/pages/Library/Artists/Artist/ArtistPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistPage.vue
@@ -17,6 +17,7 @@ import LocalImg from "@/components/LocalImg.vue";
 import WrappingMarquee from "@/components/WrappingMarquee.vue";
 import { watchAsync } from "@/utils/vue";
 import { IonSkeletonText, IonThumbnail } from "@ionic/vue";
+import { useWindowSize } from "@vueuse/core";
 import { computed, ref } from "vue";
 
 const musicPlayer = useMusicPlayer();
@@ -55,6 +56,8 @@ async function playSong(song: Song | SongPreview<SongType, true>): Promise<void>
 async function goToSong(song: Song | SongPreview<SongType, true>): Promise<void> {
 	await router.push(`/library/songs/${song.type}/${song.id}`);
 }
+
+const { width: windowWidth } = useWindowSize();
 </script>
 
 <template>
@@ -70,10 +73,11 @@ async function goToSong(song: Song | SongPreview<SongType, true>): Promise<void>
 				<!-- TODO: Display all songs of the artist on click -->
 				<h1>Top Songs</h1>
 				<div class="top-songs-container">
-					<!-- TODO: Make this responsive-->
 					<div
 						class="top-songs-items"
-						:style="{ '--top-songs-rows': Math.min(3, Math.ceil(artist.songs.length / 4)) }"
+						:style="{
+							'--top-songs-rows': Math.min(3, Math.floor((artist.songs.length * 280) / windowWidth)),
+						}"
 					>
 						<GenericSongItem
 							@item-click="playSong(song)"
@@ -242,7 +246,7 @@ async function goToSong(song: Song | SongPreview<SongType, true>): Promise<void>
 			& > .top-songs-items {
 				display: grid;
 				grid-template-rows: repeat(var(--top-songs-rows), 1fr);
-				grid-auto-flow: column;
+				grid-auto-flow: column dense;
 				grid-auto-columns: min(80vw, 290px);
 
 				width: max-content;

--- a/src/pages/Library/Artists/Artist/ArtistPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistPage.vue
@@ -142,7 +142,9 @@ const { width: windowWidth } = useWindowSize();
 		font-size: min(2.125rem, 61.2px);
 		font-weight: bold;
 
-		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		& .wrapping {
+			mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		}
 
 		margin-top: 0;
 		margin-bottom: 0.25rem;

--- a/src/pages/Library/Artists/Artist/ArtistPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistPage.vue
@@ -11,12 +11,14 @@ import {
 import { useMusicPlayer } from "@/stores/music-player";
 import { useRoute, useRouter } from "vue-router";
 
+import { IonIcon, IonSkeletonText, IonThumbnail } from "@ionic/vue";
+import { chevronForward as chevronForwardIcon } from "ionicons/icons";
+
 import GenericAlbumCard from "@/components/GenericAlbumCard.vue";
 import GenericSongItem from "@/components/GenericSongItem.vue";
 import LocalImg from "@/components/LocalImg.vue";
 import WrappingMarquee from "@/components/WrappingMarquee.vue";
 import { watchAsync } from "@/utils/vue";
-import { IonSkeletonText, IonThumbnail } from "@ionic/vue";
 import { useWindowSize } from "@vueuse/core";
 import { computed, ref } from "vue";
 
@@ -71,7 +73,11 @@ const { width: windowWidth } = useWindowSize();
 
 			<section class="top-songs" v-if="artist.songs.length">
 				<!-- TODO: Display all songs of the artist on click -->
-				<h1>Top Songs</h1>
+				<h1>
+					<RouterLink :to="`/library/artists/${artist.type}/${artist.id}/songs`">Top Songs</RouterLink>
+					<ion-icon :icon="chevronForwardIcon" />
+				</h1>
+
 				<div class="top-songs-container">
 					<div
 						class="top-songs-items"
@@ -228,8 +234,19 @@ const { width: windowWidth } = useWindowSize();
 		align-items: start;
 
 		& > h1 {
+			display: inline-flex;
+			align-items: center;
 			margin-left: 0.5em;
 			font-weight: bold;
+
+			& > a {
+				color: var(--ion-color-dark-rgb);
+				text-decoration: none;
+			}
+
+			& > ion-icon {
+				color: var(--ion-color-medium);
+			}
 		}
 
 		& > .top-songs-container {

--- a/src/pages/Library/Artists/Artist/ArtistPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistPage.vue
@@ -1,0 +1,178 @@
+<script lang="ts" setup>
+import { computedAsync } from "@vueuse/core";
+
+import AppPage from "@/components/AppPage.vue";
+import { filledArtist, SongType } from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
+import { useRoute, useRouter } from "vue-router";
+
+import LocalImg from "@/components/LocalImg.vue";
+import WrappingMarquee from "@/components/WrappingMarquee.vue";
+import { IonSkeletonText, IonThumbnail } from "@ionic/vue";
+import { computed } from "vue";
+
+const musicPlayer = useMusicPlayer();
+const router = useRouter();
+const route = useRoute();
+
+const previousRouteName = computed(() => {
+	const { state } = router.options.history;
+	if (!("back" in state)) return "Songs";
+	return String(router.resolve(state.back as any)?.name);
+});
+
+const artist = computedAsync(async () => {
+	const artist = await musicPlayer.services.getArtist(
+		route.params.artistType as SongType,
+		route.params.artistId as string,
+	);
+
+	return artist && filledArtist(artist);
+});
+</script>
+
+<template>
+	<AppPage :back-button="previousRouteName">
+		<div id="artist-content" v-if="artist">
+			<LocalImg :src="artist.artwork" />
+			<h1 class="ion-text-nowrap">
+				<WrappingMarquee :text="artist.title ?? 'Unknown title'" />
+			</h1>
+
+			{{ artist.albums.length }}
+			{{ artist.songs.length }}
+		</div>
+		<div id="artist-loading-content" v-else>
+			<ion-thumbnail>
+				<ion-skeleton-text :animated="true" />
+			</ion-thumbnail>
+			<h1><ion-skeleton-text :animated="true" /></h1>
+			<h2><ion-skeleton-text :animated="true" /></h2>
+		</div>
+	</AppPage>
+</template>
+
+<style scoped>
+@keyframes fade-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+#artist-content {
+	text-align: center;
+
+	animation: fade-in 350ms;
+
+	& > h1 {
+		font-size: min(2.125rem, 61.2px);
+		font-weight: bold;
+
+		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+
+		margin-top: 0;
+		margin-bottom: 0.25rem;
+
+		--marquee-duration: 20s;
+		--marquee-align: center;
+	}
+
+	& > .artist,
+	& > .album {
+		display: block;
+
+		color: var(--ion-color-dark-rgb);
+		text-decoration: none;
+
+		width: max-content;
+
+		margin-top: 0;
+		margin-bottom: 10px;
+		margin-inline: auto;
+
+		cursor: pointer;
+		&:hover {
+			opacity: 80%;
+
+			@media (pointer: fine) {
+				text-decoration: underline;
+			}
+		}
+		&:active {
+			opacity: 60%;
+		}
+	}
+
+	& > .artist {
+		font-size: 1.25rem;
+		font-weight: 550;
+	}
+
+	& > .album {
+		font-size: 1rem;
+		font-weight: 450;
+	}
+
+	& > ion-button {
+		&::part(native) {
+			width: 33%;
+			margin-inline: auto;
+		}
+
+		width: 100%;
+		padding-bottom: 1rem;
+	}
+
+	& > .local-img {
+		margin-inline: auto;
+
+		--img-height: 192px;
+		--img-width: auto;
+
+		--shadow-color: rgba(var(--ion-color-dark-rgb), 0.1);
+
+		border-radius: 12px;
+		box-shadow: 0 0 12px var(--shadow-color);
+		margin-block: 24px;
+		background-color: rgba(var(--ion-color-dark-rgb), 0.08);
+
+		& > .fallback {
+			--size: 36px;
+			filter: drop-shadow(0 0 12px var(--shadow-color));
+		}
+	}
+}
+
+#artist-loading-content {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	animation: fade-in 350ms;
+
+	& > ion-thumbnail {
+		margin-inline: auto;
+		margin-block: 24px;
+
+		height: 192px;
+		width: 192px;
+		--border-radius: 12px;
+	}
+
+	& > h1 {
+		width: 50%;
+		height: 20px;
+		margin-top: 0;
+		margin-bottom: 0.25rem;
+	}
+
+	& > h2 {
+		width: 40%;
+		margin-top: 0;
+	}
+}
+</style>

--- a/src/pages/Library/Artists/Artist/ArtistPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistPage.vue
@@ -56,7 +56,7 @@ async function playSong(song: Song | SongPreview<SongType, true>): Promise<void>
 }
 
 async function goToSong(song: Song | SongPreview<SongType, true>): Promise<void> {
-	await router.push(`/library/songs/${song.type}/${song.id}`);
+	await router.push(`/items/songs/${song.type}/${song.id}`);
 }
 
 const { width: windowWidth } = useWindowSize();
@@ -74,7 +74,7 @@ const { width: windowWidth } = useWindowSize();
 			<section class="top-songs" v-if="artist.songs.length">
 				<!-- TODO: Display all songs of the artist on click -->
 				<h1>
-					<RouterLink :to="`/library/artists/${artist.type}/${artist.id}/songs`">Top Songs</RouterLink>
+					<RouterLink :to="`/items/artists/${artist.type}/${artist.id}/songs`">Top Songs</RouterLink>
 					<ion-icon :icon="chevronForwardIcon" />
 				</h1>
 
@@ -112,7 +112,7 @@ const { width: windowWidth } = useWindowSize();
 							:key="album.id"
 							:title="album.title"
 							:artwork="album.artwork"
-							:router-link="`/library/albums/album/${album.type}/${album.id}`"
+							:router-link="`/items/albums/album/${album.type}/${album.id}`"
 						/>
 					</div>
 				</div>

--- a/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
@@ -89,7 +89,7 @@ async function playSong(song: Song | SongPreview<SongType>): Promise<void> {
 }
 
 async function goToSong(song: Song | SongPreview<SongType>): Promise<void> {
-	await router.push(`/library/songs/${song.type}/${song.id}`);
+	await router.push(`/items/songs/${song.type}/${song.id}`);
 }
 </script>
 

--- a/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
@@ -42,7 +42,13 @@ const artist = ref<Filled<Artist>>();
 watchAsync(
 	() => [route.params.artistType, route.params.artistId],
 	async ([artistType, artistId]) => {
-		if (!artistType || !artistId) return;
+		if (!artistType || !artistId) {
+			return;
+		}
+
+		if (artist.value?.id === artistId && artist.value?.type === artistType) {
+			return;
+		}
 
 		const $artist = await musicPlayer.services.getArtist(
 			route.params.artistType as SongType,

--- a/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed, inject, reactive, ref, Ref, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import {
+	InfiniteScrollCustomEvent,
+	IonInfiniteScroll,
+	IonInfiniteScrollContent,
+	IonItem,
+	IonList,
+} from "@ionic/vue";
+
+import AppPage from "@/components/AppPage.vue";
+import GenericSongItem from "@/components/GenericSongItem.vue";
+import SkeletonItem from "@/components/SkeletonItem.vue";
+
+import {
+	Artist,
+	Filled,
+	filledArtist,
+	Song,
+	SongPreview,
+	SongType,
+} from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
+import { watchAsync } from "@/utils/vue";
+
+const musicPlayer = useMusicPlayer();
+const router = useRouter();
+const route = useRoute();
+
+const previousRouteName = computed(() => {
+	const { state } = router.options.history;
+	if (!("back" in state)) return "Songs";
+	return String(router.resolve(state.back as any)?.name);
+});
+
+const songs = reactive<(Song | SongPreview)[]>([]);
+
+const isLoading = ref(true);
+const artist = ref<Filled<Artist>>();
+watchAsync(
+	() => [route.params.artistType, route.params.artistId],
+	async ([artistType, artistId]) => {
+		if (!artistType || !artistId) return;
+
+		const $artist = await musicPlayer.services.getArtist(
+			route.params.artistType as SongType,
+			route.params.artistId as string,
+		);
+
+		artist.value = $artist && filledArtist($artist);
+	},
+	{ immediate: true },
+);
+
+const offset = ref(0);
+watchAsync(artist, async (artist) => {
+	songs.length = 0;
+	offset.value = 0;
+	if (!artist) return;
+
+	isLoading.value = true;
+	for await (const song of musicPlayer.services.getArtistsSongs(artist.id, 0)) {
+		songs.push(song);
+	}
+	isLoading.value = false;
+});
+
+async function loadMoreSongs(event: InfiniteScrollCustomEvent): Promise<void> {
+	if (!artist.value) return;
+	offset.value += 1;
+	for await (const song of musicPlayer.services.getArtistsSongs(artist.value.id, offset.value)) {
+		songs.push(song);
+	}
+	await event.target.complete();
+}
+</script>
+
+<template>
+	<AppPage :back-button="previousRouteName" title="Top Songs">
+		<ion-list v-if="isLoading" class="songs-list">
+			<SkeletonItem v-for="i in 25" :key="i" />
+		</ion-list>
+		<ion-list v-else-if="artist">
+			<GenericSongItem
+				v-for="song in songs"
+				:key="song.id"
+				:title="song.title"
+				:album="song.album"
+				:artwork="song.artwork"
+				:disabled="!song.available"
+			/>
+		</ion-list>
+
+		<ion-infinite-scroll v-if="artist" @ion-infinite="loadMoreSongs">
+			<ion-infinite-scroll-content loading-spinner="dots" />
+		</ion-infinite-scroll>
+	</AppPage>
+</template>

--- a/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
@@ -1,12 +1,11 @@
 <script setup lang="ts">
-import { computed, inject, reactive, ref, Ref, watch } from "vue";
+import { computed, reactive, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import {
 	InfiniteScrollCustomEvent,
 	IonInfiniteScroll,
 	IonInfiniteScrollContent,
-	IonItem,
 	IonList,
 } from "@ionic/vue";
 
@@ -81,6 +80,17 @@ async function loadMoreSongs(event: InfiniteScrollCustomEvent): Promise<void> {
 	}
 	await event.target.complete();
 }
+
+async function playSong(song: Song | SongPreview<SongType>): Promise<void> {
+	await musicPlayer.state.addToQueue(
+		await musicPlayer.services.retrieveSong(song),
+		musicPlayer.state.queueIndex,
+	);
+}
+
+async function goToSong(song: Song | SongPreview<SongType>): Promise<void> {
+	await router.push(`/library/songs/${song.type}/${song.id}`);
+}
 </script>
 
 <template>
@@ -91,6 +101,8 @@ async function loadMoreSongs(event: InfiniteScrollCustomEvent): Promise<void> {
 		<ion-list v-else-if="artist">
 			<GenericSongItem
 				v-for="song in songs"
+				@item-click="playSong(song)"
+				@context-menu-click="goToSong(song)"
 				:key="song.id"
 				:title="song.title"
 				:album="song.album"

--- a/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
+++ b/src/pages/Library/Artists/Artist/ArtistsSongsPage.vue
@@ -61,7 +61,7 @@ watchAsync(artist, async (artist) => {
 	if (!artist) return;
 
 	isLoading.value = true;
-	for await (const song of musicPlayer.services.getArtistsSongs(artist.id, 0)) {
+	for await (const song of musicPlayer.services.getArtistsSongs(artist, 0)) {
 		songs.push(song);
 	}
 	isLoading.value = false;
@@ -70,7 +70,7 @@ watchAsync(artist, async (artist) => {
 async function loadMoreSongs(event: InfiniteScrollCustomEvent): Promise<void> {
 	if (!artist.value) return;
 	offset.value += 1;
-	for await (const song of musicPlayer.services.getArtistsSongs(artist.value.id, offset.value)) {
+	for await (const song of musicPlayer.services.getArtistsSongs(artist.value, offset.value)) {
 		songs.push(song);
 	}
 	await event.target.complete();

--- a/src/pages/Library/Artists/ArtistsPage.vue
+++ b/src/pages/Library/Artists/ArtistsPage.vue
@@ -1,0 +1,43 @@
+<script lang="ts" setup>
+import { useSessionStorage } from "@vueuse/core";
+import { onUpdated, ref } from "vue";
+
+import AppPage from "@/components/AppPage.vue";
+import LocalImg from "@/components/LocalImg.vue";
+import SkeletonItem from "@/components/SkeletonItem.vue";
+import { IonItem, IonList } from "@ionic/vue";
+
+import { Artist, ArtistPreview } from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
+
+const musicPlayer = useMusicPlayer();
+
+const libraryArtists = useSessionStorage<(Artist | ArtistPreview)[]>("libraryArtists", []);
+const isLoading = ref(libraryArtists.value.length === 0);
+onUpdated(async () => {
+	if (!libraryArtists.value.length) {
+		console.log("getting those mfs");
+		isLoading.value = true;
+		for await (const artist of musicPlayer.services.libraryArtists()) {
+			console.log(artist);
+			libraryArtists.value.push(artist);
+		}
+		console.log("thats all");
+		isLoading.value = false;
+	}
+});
+</script>
+
+<template>
+	<AppPage title="Artists" back-button="Library">
+		<ion-list v-if="isLoading" class="songs-list">
+			<SkeletonItem v-for="i in 25" :key="i" />
+		</ion-list>
+		<ion-list v-else class="songs-list">
+			<ion-item v-for="artist in libraryArtists" :key="artist.id">
+				<LocalImg :src="artist.artwork" />
+				{{ artist.title }}
+			</ion-item>
+		</ion-list>
+	</AppPage>
+</template>

--- a/src/pages/Library/Artists/ArtistsPage.vue
+++ b/src/pages/Library/Artists/ArtistsPage.vue
@@ -52,4 +52,12 @@ async function refreshArtistLibrary(event: RefresherCustomEvent): Promise<void> 
 	</AppPage>
 </template>
 
-<style></style>
+<style>
+.songs-list {
+	& > .skeleton-item {
+		& > ion-thumbnail {
+			--border-radius: 9999px;
+		}
+	}
+}
+</style>

--- a/src/pages/Library/Artists/ArtistsPage.vue
+++ b/src/pages/Library/Artists/ArtistsPage.vue
@@ -3,9 +3,9 @@ import { useSessionStorage } from "@vueuse/core";
 import { onUpdated, ref } from "vue";
 
 import AppPage from "@/components/AppPage.vue";
-import LocalImg from "@/components/LocalImg.vue";
 import SkeletonItem from "@/components/SkeletonItem.vue";
-import { IonItem, IonList } from "@ionic/vue";
+import { IonList, IonRefresher, IonRefresherContent, RefresherCustomEvent } from "@ionic/vue";
+import ArtistItem from "./components/ArtistItem.vue";
 
 import { Artist, ArtistPreview } from "@/services/Music/objects";
 import { useMusicPlayer } from "@/stores/music-player";
@@ -16,28 +16,40 @@ const libraryArtists = useSessionStorage<(Artist | ArtistPreview)[]>("libraryArt
 const isLoading = ref(libraryArtists.value.length === 0);
 onUpdated(async () => {
 	if (!libraryArtists.value.length) {
-		console.log("getting those mfs");
 		isLoading.value = true;
 		for await (const artist of musicPlayer.services.libraryArtists()) {
 			console.log(artist);
 			libraryArtists.value.push(artist);
 		}
-		console.log("thats all");
 		isLoading.value = false;
 	}
 });
+
+async function refreshArtistLibrary(event: RefresherCustomEvent): Promise<void> {
+	isLoading.value = true;
+	await musicPlayer.services.refreshLibraryArtists();
+	libraryArtists.value.length = 0;
+	for await (const song of musicPlayer.services.libraryArtists()) {
+		libraryArtists.value.push(song);
+	}
+	isLoading.value = false;
+	await event.target.complete();
+}
 </script>
 
 <template>
 	<AppPage title="Artists" back-button="Library">
+		<ion-refresher slot="fixed" @ion-refresh="refreshArtistLibrary">
+			<ion-refresher-content />
+		</ion-refresher>
+
 		<ion-list v-if="isLoading" class="songs-list">
 			<SkeletonItem v-for="i in 25" :key="i" />
 		</ion-list>
 		<ion-list v-else class="songs-list">
-			<ion-item v-for="artist in libraryArtists" :key="artist.id">
-				<LocalImg :src="artist.artwork" />
-				{{ artist.title }}
-			</ion-item>
+			<ArtistItem v-for="artist in libraryArtists" :artist :key="artist.id" />
 		</ion-list>
 	</AppPage>
 </template>
+
+<style></style>

--- a/src/pages/Library/Artists/ArtistsPage.vue
+++ b/src/pages/Library/Artists/ArtistsPage.vue
@@ -43,17 +43,17 @@ async function refreshArtistLibrary(event: RefresherCustomEvent): Promise<void> 
 			<ion-refresher-content />
 		</ion-refresher>
 
-		<ion-list v-if="isLoading" class="songs-list">
+		<ion-list v-if="isLoading" class="artists-list">
 			<SkeletonItem v-for="i in 25" :key="i" />
 		</ion-list>
-		<ion-list v-else class="songs-list">
+		<ion-list v-else class="artists-list">
 			<ArtistItem v-for="artist in libraryArtists" :artist :key="artist.id" />
 		</ion-list>
 	</AppPage>
 </template>
 
 <style>
-.songs-list {
+.artists-list {
 	& > .skeleton-item {
 		& > ion-thumbnail {
 			--border-radius: 9999px;

--- a/src/pages/Library/Artists/components/ArtistItem.vue
+++ b/src/pages/Library/Artists/components/ArtistItem.vue
@@ -1,0 +1,128 @@
+<script lang="ts" setup>
+import LocalImg from "@/components/LocalImg.vue";
+import { IonIcon, IonItem, IonLabel, IonNote } from "@ionic/vue";
+import { compass as compassIcon } from "ionicons/icons";
+
+import ContextMenu from "@/components/ContextMenu.vue";
+import { Artist, ArtistPreview } from "@/services/Music/objects";
+import { songTypeToDisplayName } from "@/utils/songs";
+
+const { artist } = defineProps<{ artist: Artist | ArtistPreview }>();
+</script>
+
+<template>
+	<ContextMenu ref="contextMenu">
+		<ion-item :router-link="`/library/artists/${artist.type}/${artist.id}`">
+			<LocalImg
+				v-if="artist.artwork"
+				slot="start"
+				:src="artist.artwork"
+				:alt="`Artwork for artist '${artist.title}'`"
+			/>
+
+			<ion-label>
+				<h1>{{ artist.title }}</h1>
+				<ion-note>
+					<p>
+						<ion-icon :icon="compassIcon" />
+						{{ songTypeToDisplayName(artist.type) }}
+					</p>
+				</ion-note>
+			</ion-label>
+		</ion-item>
+	</ContextMenu>
+</template>
+
+<style scoped>
+.context-menu:not(.closed) > .context-menu-item > ion-item {
+	transition: var(--context-menu-transition);
+
+	--background: var(--context-menu-item-background);
+
+	border-radius: 24px;
+	--border-color: transparent;
+
+	--padding-top: 12px;
+	--padding-bottom: 12px;
+	--padding-start: 12px;
+	--padding-end: 12px;
+
+	& > .local-img {
+		transition: var(--context-menu-transition);
+
+		--img-border-radius: 12px;
+		--img-width: 96px;
+		--img-height: auto;
+	}
+
+	& > ion-label {
+		height: max-content;
+		white-space: normal;
+
+		& > h1 {
+			font-size: 1.2rem;
+			line-height: 1;
+
+			@supports (line-clamp: 2) {
+				line-clamp: 2;
+			}
+
+			@supports not (line-clamp: 2) {
+				max-height: 2em;
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+		}
+
+		& > ion-note {
+			margin-top: 1em;
+			flex-direction: column;
+			align-items: start;
+
+			& > p {
+				align-items: start;
+				font-size: 1.1em;
+			}
+		}
+	}
+}
+
+ion-item {
+	& > .local-img {
+		pointer-events: none;
+
+		--img-border-radius: 999px;
+		--img-width: auto;
+		--img-height: 56px;
+	}
+
+	& > ion-label {
+		pointer-events: none;
+		white-space: nowrap;
+
+		& > h1 {
+			font-size: 0.9em;
+			font-weight: 550;
+			display: block;
+		}
+
+		& > ion-note {
+			display: flex;
+			gap: 0.5ch;
+			align-items: center;
+			font-size: 0.75em;
+
+			& > p {
+				display: flex;
+				align-items: center;
+				gap: 4px;
+				font-size: inherit;
+
+				& > ion-icon {
+					min-width: 1em;
+				}
+			}
+		}
+	}
+}
+</style>

--- a/src/pages/Library/Artists/components/ArtistItem.vue
+++ b/src/pages/Library/Artists/components/ArtistItem.vue
@@ -12,7 +12,7 @@ const { artist } = defineProps<{ artist: Artist | ArtistPreview }>();
 
 <template>
 	<ContextMenu ref="contextMenu">
-		<ion-item :router-link="`/library/artists/${artist.type}/${artist.id}`">
+		<ion-item :router-link="`/items/artists/${artist.type}/${artist.id}`">
 			<LocalImg
 				v-if="artist.artwork"
 				slot="start"

--- a/src/pages/Library/LibraryPage.vue
+++ b/src/pages/Library/LibraryPage.vue
@@ -14,6 +14,11 @@
 			<ion-icon color="primary" :icon="songsIcon" class="padded-icon" size="large" slot="start" />
 			<ion-label>Songs</ion-label>
 		</ion-item>
+
+		<ion-item router-link="/library/artists">
+			<ion-icon color="primary" :icon="artistsIcon" class="padded-icon" size="large" slot="start" />
+			<ion-label>Artists</ion-label>
+		</ion-item>
 	</AppPage>
 </template>
 
@@ -23,6 +28,7 @@ import AppPage from "@/components/AppPage.vue";
 import { IonIcon, IonItem, IonLabel } from "@ionic/vue";
 import {
 	albumsOutline as albumsIcon,
+	peopleOutline as artistsIcon,
 	musicalNotesOutline as playlistsIcon,
 	musicalNoteOutline as songsIcon,
 } from "ionicons/icons";

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -29,13 +29,17 @@ import {
 	playOutline as playSongNextIcon,
 } from "ionicons/icons";
 
-import { AnySong, useMusicPlayer } from "@/stores/music-player";
+import { filledPlaylist, Song } from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
 import { useRoute } from "vue-router";
 
 const musicPlayer = useMusicPlayer();
 const route = useRoute();
 
-const playlist = computed(() => musicPlayer.state.getPlaylist(route.params.id as string));
+const playlist = computed(() => {
+	const playlist = musicPlayer.state.getPlaylist(route.params.id as string);
+	return playlist && filledPlaylist(playlist);
+});
 const isEmpty = computed(() => !playlist.value?.songs.length);
 const totalDuration = computed(() => {
 	const songs = playlist?.value?.songs ?? [];
@@ -69,19 +73,19 @@ function onDeleteActionDismiss(event: CustomEvent): void {
 
 const router = useIonRouter();
 
-async function playSong(song: AnySong): Promise<void> {
+async function playSong(song: Song): Promise<void> {
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex);
 }
 
-async function playSongNext(song: AnySong): Promise<void> {
+async function playSongNext(song: Song): Promise<void> {
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex + 1);
 }
 
-async function addSongToQueue(song: AnySong): Promise<void> {
+async function addSongToQueue(song: Song): Promise<void> {
 	await musicPlayer.state.addToQueue(song);
 }
 
-function goToSong(song: AnySong): void {
+function goToSong(song: Song): void {
 	router.push(`/library/songs/${song.type}/${song.id}`);
 }
 </script>

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -123,12 +123,10 @@ function goToSong(song: AnySong): void {
 			<template v-else>
 				<h2>{{ playlist.songs.length }} songs, {{ Math.round(totalDuration / 60) }} minutes</h2>
 
-				<div class="buttons">
-					<ion-button strong @click="play">
-						<ion-icon slot="start" :icon="playIcon" />
-						Play
-					</ion-button>
-				</div>
+				<ion-button strong @click="play">
+					<ion-icon slot="start" :icon="playIcon" />
+					Play
+				</ion-button>
 
 				<ion-list>
 					<GenericSongItem
@@ -165,11 +163,12 @@ function goToSong(song: AnySong): void {
 	text-align: center;
 
 	& > ion-header {
+		width: max-content;
+		margin-inline: auto;
 		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
 
 		& ion-title {
 			transform-origin: top center;
-			justify-content: center;
 
 			font-weight: bold;
 			margin: 0;

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -122,10 +122,13 @@ function goToSong(song: AnySong): void {
 			<ion-note v-if="isEmpty">This playlist has no songs, fill it up!</ion-note>
 			<template v-else>
 				<h2>{{ playlist.songs.length }} songs, {{ Math.round(totalDuration / 60) }} minutes</h2>
-				<ion-button strong @click="play">
-					<ion-icon slot="start" :icon="playIcon" />
-					Play
-				</ion-button>
+
+				<div class="buttons">
+					<ion-button strong @click="play">
+						<ion-icon slot="start" :icon="playIcon" />
+						Play
+					</ion-button>
+				</div>
 
 				<ion-list>
 					<GenericSongItem
@@ -193,7 +196,7 @@ function goToSong(song: AnySong): void {
 			var(--ion-color-step-250, var(--ion-background-color-step-250, #c8c7cc));
 	}
 
-	& > .song-img {
+	& > .local-img {
 		margin-inline: auto;
 
 		--img-height: 192px;

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -164,6 +164,7 @@ function goToSong(song: AnySong): void {
 
 	& > ion-header {
 		width: max-content;
+		max-width: 100%;
 		margin-inline: auto;
 		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
 

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -86,7 +86,7 @@ async function addSongToQueue(song: Song): Promise<void> {
 }
 
 function goToSong(song: Song): void {
-	router.push(`/library/songs/${song.type}/${song.id}`);
+	router.push(`/items/songs/${song.type}/${song.id}`);
 }
 </script>
 

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -4,6 +4,7 @@ import { computed } from "vue";
 import AppPage from "@/components/AppPage.vue";
 import GenericSongItem from "@/components/GenericSongItem.vue";
 import LocalImg from "@/components/LocalImg.vue";
+import WrappingMarquee from "@/components/WrappingMarquee.vue";
 import PlaylistEditModal, { PlaylistEditEvent } from "../components/PlaylistEditModal.vue";
 
 import {
@@ -11,10 +12,13 @@ import {
 	IonActionSheet,
 	IonButton,
 	IonButtons,
+	IonHeader,
 	IonIcon,
 	IonItem,
 	IonList,
 	IonNote,
+	IonTitle,
+	IonToolbar,
 	useIonRouter,
 } from "@ionic/vue";
 import {
@@ -106,7 +110,14 @@ function goToSong(song: AnySong): void {
 
 		<div id="playlist-content" v-if="playlist">
 			<LocalImg :src="playlist.artwork" />
-			<h1>{{ playlist?.title }}</h1>
+
+			<ion-header collapse="condense">
+				<ion-toolbar>
+					<ion-title class="ion-text-nowrap" size="large">
+						<WrappingMarquee :text="playlist.title" />
+					</ion-title>
+				</ion-toolbar>
+			</ion-header>
 
 			<ion-note v-if="isEmpty">This playlist has no songs, fill it up!</ion-note>
 			<template v-else>
@@ -150,10 +161,19 @@ function goToSong(song: AnySong): void {
 #playlist-content {
 	text-align: center;
 
-	& > h1 {
-		font-weight: bold;
-		margin-top: 0;
-		margin-bottom: 0.25rem;
+	& > ion-header {
+		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+
+		& ion-title {
+			transform-origin: top center;
+			justify-content: center;
+
+			font-weight: bold;
+			margin: 0;
+
+			--marquee-duration: 20s;
+			--marquee-align: center;
+		}
 	}
 
 	& > h2 {

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -48,7 +48,7 @@ const deleteActionSheetButtons: ActionSheetButton[] = [
 ];
 
 function play(): void {
-	musicPlayer.state.setQueue(playlist.value!.songs);
+	musicPlayer.state.setQueue(playlist.value!.songs.filter((song) => song.available));
 	musicPlayer.state.queueIndex = 0;
 }
 
@@ -131,6 +131,7 @@ function goToSong(song: AnySong): void {
 				<ion-list>
 					<GenericSongItem
 						v-for="song in playlist.songs"
+						:disabled="!song.available"
 						:key="song.id"
 						:title="song.title"
 						:artists="song.artists"

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -171,7 +171,10 @@ function goToSong(song: Song): void {
 		width: max-content;
 		max-width: 100%;
 		margin-inline: auto;
-		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+
+		& .wrapping {
+			mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		}
 
 		& ion-title {
 			transform-origin: top center;

--- a/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
+++ b/src/pages/Library/Playlists/Playlist/PlaylistPage.vue
@@ -83,7 +83,7 @@ function goToSong(song: AnySong): void {
 </script>
 
 <template>
-	<AppPage back-button="Playlists">
+	<AppPage :title="playlist?.title" :show-content-header="false" back-button="Playlists">
 		<template #toolbar-end>
 			<ion-buttons>
 				<ion-button id="edit-playlist">

--- a/src/pages/Library/Playlists/PlaylistsPage.vue
+++ b/src/pages/Library/Playlists/PlaylistsPage.vue
@@ -41,7 +41,7 @@ const musicPlayer = useMusicPlayer();
 			<ion-item
 				v-for="playlist in musicPlayer.state.playlists"
 				:key="playlist.id"
-				:router-link="`/library/playlists/${playlist.id}`"
+				:router-link="`/items/playlists/${playlist.id}`"
 			>
 				<ion-thumbnail slot="start">
 					<LocalImg :src="playlist.artwork" :alt="`Artwork for playlist '${playlist.title}'`" />

--- a/src/pages/Library/Playlists/PlaylistsPage.vue
+++ b/src/pages/Library/Playlists/PlaylistsPage.vue
@@ -64,22 +64,12 @@ const musicPlayer = useMusicPlayer();
 		--background: transparent;
 		min-height: 60px;
 
-		& > ion-thumbnail > .song-img {
-			border-radius: 8px;
-		}
-	}
-}
+		& > ion-thumbnail {
+			display: flex;
+			align-items: center;
 
-#playlist-add-modal-content {
-	& > ion-list {
-		background: transparent;
-		& > ion-item {
-			--background: transparent;
-
-			& > ion-input {
-				font-weight: 600;
-				font-size: 1.25rem;
-				text-align: center;
+			& > .local-img {
+				border-radius: 8px;
 			}
 		}
 	}

--- a/src/pages/Library/Playlists/components/PlaylistAddModal.vue
+++ b/src/pages/Library/Playlists/components/PlaylistAddModal.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { computed, ref, toRaw, useTemplateRef } from "vue";
 
-import SongImagePicker from "@/components/SongImagePicker.vue";
+import LocalImagePicker from "@/components/LocalImagePicker.vue";
 import {
 	actionSheetController,
 	IonButton,
@@ -103,7 +103,7 @@ async function canDismiss(reason?: "createdPlaylist"): Promise<boolean> {
 		</ion-header>
 
 		<ion-content id="add-playlist-content" :fullscreen="true">
-			<SongImagePicker :id="playlistId" @input="artwork = $event.value" />
+			<LocalImagePicker :id="playlistId" @input="artwork = $event.value" />
 
 			<ion-list>
 				<ion-item>
@@ -140,7 +140,7 @@ async function canDismiss(reason?: "createdPlaylist"): Promise<boolean> {
 			var(--ion-color-step-250, var(--ion-background-color-step-250, #c8c7cc));
 	}
 
-	& > .song-img {
+	& > .local-img {
 		margin-inline: auto;
 
 		--shadow-color: rgba(var(--ion-color-dark-rgb), 0.1);

--- a/src/pages/Library/Playlists/components/PlaylistAddModal.vue
+++ b/src/pages/Library/Playlists/components/PlaylistAddModal.vue
@@ -45,6 +45,9 @@ function create(): void {
 
 	musicPlayer.state.addPlaylist({
 		id: playlistId.value,
+		kind: "playlist",
+		type: "unimusic",
+
 		title: playlistTitle.value,
 		artwork: toRaw(artwork.value),
 		songs: [],

--- a/src/pages/Library/Playlists/components/PlaylistEditModal.vue
+++ b/src/pages/Library/Playlists/components/PlaylistEditModal.vue
@@ -10,7 +10,7 @@ export interface PlaylistEditEvent {
 <script lang="ts" setup>
 import { computed, ref, toRaw, useTemplateRef } from "vue";
 
-import SongImagePicker from "@/components/SongImagePicker.vue";
+import LocalImagePicker from "@/components/LocalImagePicker.vue";
 import {
 	actionSheetController,
 	IonButton,
@@ -101,7 +101,7 @@ async function canDismiss(reason?: "editedPlaylist"): Promise<boolean> {
 		</ion-header>
 
 		<ion-content id="edit-playlist-content" :fullscreen="true">
-			<SongImagePicker :id="playlist.id" @input="((artwork = $event.value), (modified = true))" />
+			<LocalImagePicker :id="playlist.id" @input="((artwork = $event.value), (modified = true))" />
 
 			<ion-list>
 				<ion-item>

--- a/src/pages/Library/Playlists/components/PlaylistEditModal.vue
+++ b/src/pages/Library/Playlists/components/PlaylistEditModal.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { Filled, Playlist } from "@/services/Music/objects";
 import { LocalImage } from "@/stores/local-images";
 
 export interface PlaylistEditEvent {
@@ -25,12 +26,11 @@ import {
 	IonToolbar,
 } from "@ionic/vue";
 
-import { Playlist } from "@/stores/music-player";
 import { usePresentingElement } from "@/utils/vue";
 
 const { trigger, playlist } = defineProps<{
 	trigger: string;
-	playlist: Playlist;
+	playlist: Filled<Playlist>;
 }>();
 const emit = defineEmits<{
 	change: [PlaylistEditEvent];

--- a/src/pages/Library/Playlists/components/PlaylistImportModal.vue
+++ b/src/pages/Library/Playlists/components/PlaylistImportModal.vue
@@ -214,7 +214,7 @@ async function canDismiss(data?: "importedPlaylist"): Promise<boolean> {
 		margin-top: 0;
 	}
 
-	& > .song-img {
+	& > .local-img {
 		margin-inline: auto;
 
 		--img-height: 192px;

--- a/src/pages/Library/Playlists/components/PlaylistImportModal.vue
+++ b/src/pages/Library/Playlists/components/PlaylistImportModal.vue
@@ -25,7 +25,8 @@ import {
 } from "@ionic/vue";
 
 import GenericSongItem from "@/components/GenericSongItem.vue";
-import { Playlist, useMusicPlayer } from "@/stores/music-player";
+import { filledPlaylist, Playlist } from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
 import { songTypeToDisplayName } from "@/utils/songs";
 import { usePresentingElement } from "@/utils/vue";
 
@@ -38,6 +39,7 @@ const presentingElement = usePresentingElement();
 const serviceType = ref();
 const url = ref();
 const playlist = ref<Playlist>();
+const playlistFilled = computed(() => playlist.value && filledPlaylist(playlist.value));
 const loading = ref(false);
 
 const canLoad = computed(() => serviceType.value && url.value && !loading.value);
@@ -177,15 +179,15 @@ async function canDismiss(data?: "importedPlaylist"): Promise<boolean> {
 				<h1>{{ playlist.title }}</h1>
 
 				<ion-note v-if="playlist.songs.length === 0">This playlist has no songs!</ion-note>
-				<template v-else>
+				<template v-else-if="playlistFilled">
 					<h2>
 						{{ playlist.songs.length }} songs,
-						{{ Math.round(playlist.songs.reduce((a, b) => a + (b.duration ?? 0), 0) / 60) }} minutes
+						{{ Math.round(playlistFilled.songs.reduce((a, b) => a + (b.duration ?? 0), 0) / 60) }} minutes
 					</h2>
 
 					<ion-list>
 						<GenericSongItem
-							v-for="song in playlist.songs"
+							v-for="song in playlistFilled.songs"
 							:key="song.id"
 							:title="song.title"
 							:artists="song.artists"

--- a/src/pages/Library/Songs/Song/SongPage.vue
+++ b/src/pages/Library/Songs/Song/SongPage.vue
@@ -90,7 +90,7 @@ async function playNow(): Promise<void> {
 				{{ song.album }}
 			</RouterLink>
 
-			<ion-button strong @click="playNow">
+			<ion-button :disabled="!song.available" strong @click="playNow">
 				<ion-icon slot="start" :icon="playIcon" />
 				Play
 			</ion-button>

--- a/src/pages/Library/Songs/Song/SongPage.vue
+++ b/src/pages/Library/Songs/Song/SongPage.vue
@@ -153,7 +153,9 @@ async function playNow(): Promise<void> {
 		font-size: min(2.125rem, 61.2px);
 		font-weight: bold;
 
-		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		& .wrapping {
+			mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+		}
 
 		margin-top: 0;
 		margin-bottom: 0.25rem;

--- a/src/pages/Library/Songs/Song/SongPage.vue
+++ b/src/pages/Library/Songs/Song/SongPage.vue
@@ -178,14 +178,17 @@ async function playNow(): Promise<void> {
 	& > h2 > .artist,
 	& > .album {
 		color: var(--ion-color-dark-rgb);
-		text-decoration: none;
 
 		width: max-content;
 
 		margin-top: 0;
 		margin-bottom: 10px;
 		margin-inline: auto;
+	}
 
+	& > h2 > a.artist,
+	& > .album {
+		text-decoration: none;
 		cursor: pointer;
 		&:hover {
 			opacity: 80%;

--- a/src/pages/Library/Songs/Song/SongPage.vue
+++ b/src/pages/Library/Songs/Song/SongPage.vue
@@ -104,7 +104,7 @@ async function playNow(): Promise<void> {
 						class="artist"
 						role="link"
 						aria-roledescription="Go to artist"
-						:to="`/library/artists/${artist.type}/${artist.id}`"
+						:to="`/items/artists/${artist.type}/${artist.id}`"
 					>
 						{{ artist.title }}
 					</RouterLink>
@@ -114,7 +114,7 @@ async function playNow(): Promise<void> {
 				</template>
 			</h2>
 
-			<RouterLink v-if="!isSingle" class="album" :to="`/library/albums/song/${song.type}/${song.id}`">
+			<RouterLink v-if="!isSingle" class="album" :to="`/items/albums/song/${song.type}/${song.id}`">
 				{{ song.album }}
 			</RouterLink>
 

--- a/src/pages/Library/Songs/Song/SongPage.vue
+++ b/src/pages/Library/Songs/Song/SongPage.vue
@@ -122,10 +122,14 @@ async function playNow(): Promise<void> {
 	animation: fade-in 350ms;
 
 	& > h1 {
-		font-weight: 550;
+		font-size: min(2.125rem, 61.2px);
+		font-weight: bold;
+
+		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+
 		margin-top: 0;
 		margin-bottom: 0.25rem;
-		mask-image: linear-gradient(to right, transparent, black 10% 90%, transparent);
+
 		--marquee-duration: 20s;
 		--marquee-align: center;
 	}
@@ -158,7 +162,7 @@ async function playNow(): Promise<void> {
 
 	& > .artist {
 		font-size: 1.25rem;
-		font-weight: bold;
+		font-weight: 550;
 	}
 
 	& > .album {

--- a/src/pages/Library/Songs/Song/SongPage.vue
+++ b/src/pages/Library/Songs/Song/SongPage.vue
@@ -176,7 +176,7 @@ async function playNow(): Promise<void> {
 		padding-bottom: 1rem;
 	}
 
-	& > .song-img {
+	& > .local-img {
 		margin-inline: auto;
 
 		--img-height: 192px;

--- a/src/pages/Library/Songs/SongsPage.vue
+++ b/src/pages/Library/Songs/SongsPage.vue
@@ -22,7 +22,7 @@ onUpdated(async () => {
 	isLoading.value = false;
 });
 
-async function refreshLocalLibrary(event: RefresherCustomEvent): Promise<void> {
+async function refreshSongLibrary(event: RefresherCustomEvent): Promise<void> {
 	await musicPlayer.services.refreshLibrarySongs();
 	librarySongs.value = await musicPlayer.services.librarySongs();
 	await event.target.complete();
@@ -31,7 +31,7 @@ async function refreshLocalLibrary(event: RefresherCustomEvent): Promise<void> {
 
 <template>
 	<AppPage title="Songs" back-button="Library">
-		<ion-refresher slot="fixed" @ion-refresh="refreshLocalLibrary($event)">
+		<ion-refresher slot="fixed" @ion-refresh="refreshSongLibrary">
 			<ion-refresher-content />
 		</ion-refresher>
 
@@ -40,9 +40,9 @@ async function refreshLocalLibrary(event: RefresherCustomEvent): Promise<void> {
 		</ion-list>
 		<ion-list v-else>
 			<GenericSongItem
-				v-for="(song, i) in librarySongs"
+				v-for="song in librarySongs"
+				:key="song.id"
 				:router-link="`/library/songs/${song.type}/${song.id}`"
-				:key="i"
 				:title="song.title"
 				:artists="song.artists"
 				:artwork="song.artwork"

--- a/src/pages/Library/Songs/SongsPage.vue
+++ b/src/pages/Library/Songs/SongsPage.vue
@@ -6,12 +6,13 @@ import { IonList, IonRefresher, IonRefresherContent, RefresherCustomEvent } from
 import AppPage from "@/components/AppPage.vue";
 import GenericSongItem from "@/components/GenericSongItem.vue";
 import SkeletonItem from "@/components/SkeletonItem.vue";
-import { AnySong, useMusicPlayer } from "@/stores/music-player";
+import { Song } from "@/services/Music/objects";
+import { useMusicPlayer } from "@/stores/music-player";
 import { useSessionStorage } from "@vueuse/core";
 
 const musicPlayer = useMusicPlayer();
 
-const librarySongs = useSessionStorage<AnySong[]>("librarySongs", []);
+const librarySongs = useSessionStorage<Song[]>("librarySongs", []);
 const isLoading = ref(librarySongs.value.length === 0);
 onUpdated(async () => {
 	if (!librarySongs.value.length) {

--- a/src/pages/Library/Songs/SongsPage.vue
+++ b/src/pages/Library/Songs/SongsPage.vue
@@ -49,7 +49,7 @@ async function refreshSongLibrary(event: RefresherCustomEvent): Promise<void> {
 			<GenericSongItem
 				v-for="song in librarySongs"
 				:key="song.id"
-				:router-link="`/library/songs/${song.type}/${song.id}`"
+				:router-link="`/items/songs/${song.type}/${song.id}`"
 				:title="song.title"
 				:artists="song.artists"
 				:artwork="song.artwork"

--- a/src/pages/Library/Songs/SongsPage.vue
+++ b/src/pages/Library/Songs/SongsPage.vue
@@ -41,14 +41,12 @@ async function refreshSongLibrary(event: RefresherCustomEvent): Promise<void> {
 			<ion-refresher-content />
 		</ion-refresher>
 
-		<ion-list class="songs-list">
-			<template v-if="isLoading">
-				<SkeletonItem v-for="i in 25" :key="i" />
-			</template>
+		<ion-list v-if="isLoading" class="songs-list">
+			<SkeletonItem v-for="i in 25" :key="i" />
+		</ion-list>
+		<ion-list v-else class="songs-list">
 			<GenericSongItem
-				v-else
 				v-for="song in librarySongs"
-				class="songs-item"
 				:key="song.id"
 				:router-link="`/library/songs/${song.type}/${song.id}`"
 				:title="song.title"
@@ -71,8 +69,7 @@ async function refreshSongLibrary(event: RefresherCustomEvent): Promise<void> {
 	}
 }
 
-.skeleton-item,
-.songs-item {
+.songs-list {
 	animation: show-up 250ms ease-in;
 }
 </style>

--- a/src/pages/Library/Songs/components/SongEditModal.vue
+++ b/src/pages/Library/Songs/components/SongEditModal.vue
@@ -59,7 +59,6 @@ const canEdit = computed(() => !!title.value && modified.value);
 function edit(): void {
 	if (!canEdit.value) return;
 
-	console.log(artwork.value);
 	emit("change", {
 		title: title.value,
 		artists: toRaw(artists.value),

--- a/src/pages/Library/Songs/components/SongEditModal.vue
+++ b/src/pages/Library/Songs/components/SongEditModal.vue
@@ -14,8 +14,8 @@ export type SongEditEvent = Maybe<{
 <script lang="ts" setup>
 import { computed, ref, toRaw, useTemplateRef } from "vue";
 
+import LocalImagePicker from "@/components/LocalImagePicker.vue";
 import MultiValueInput from "@/components/MultiValueInput.vue";
-import SongImagePicker from "@/components/SongImagePicker.vue";
 import {
 	actionSheetController,
 	IonButton,
@@ -138,7 +138,7 @@ async function canDismiss(reason?: "editedSong" | "resetSong"): Promise<boolean>
 		</ion-header>
 
 		<ion-content id="edit-song-content" :fullscreen="true">
-			<SongImagePicker
+			<LocalImagePicker
 				:id="song.id"
 				:id-out="`override-${song.id}`"
 				@input="((artwork = $event.value), (modified = true))"

--- a/src/pages/Library/Songs/components/SongEditModal.vue
+++ b/src/pages/Library/Songs/components/SongEditModal.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { ArtistPreview, filledArtistPreview, Song } from "@/services/Music/objects";
+import { DisplayableArtist, filledDisplayableArtist, Song } from "@/services/Music/objects";
 import { MetadataOverride } from "@/stores/metadata";
 import { Maybe } from "@/utils/types";
 import { computedAsync } from "@vueuse/core";
@@ -43,7 +43,7 @@ const modal = useTemplateRef("modal");
 const presentingElement = usePresentingElement();
 
 const title = ref(song.title);
-const artists = ref([...song.artists.map(filledArtistPreview).map(({ title }) => title)]);
+const artists = ref([...song.artists.map(filledDisplayableArtist).map(({ title }) => title)]);
 const album = ref(song.album);
 
 const artwork = ref(song.artwork);
@@ -61,7 +61,7 @@ const canEdit = computed(() => !!title.value && modified.value);
 function edit(): void {
 	if (!canEdit.value) return;
 
-	const editedArtists: ArtistPreview[] = artists.value.map((title) => ({
+	const editedArtists: DisplayableArtist[] = artists.value.map((title) => ({
 		title,
 	}));
 

--- a/src/pages/Search/SearchPage.vue
+++ b/src/pages/Search/SearchPage.vue
@@ -20,8 +20,7 @@ import {
 } from "ionicons/icons";
 import { ref } from "vue";
 
-import type { SongSearchResult } from "@/services/Music/MusicService";
-import { AnySong, useMusicPlayer } from "@/stores/music-player";
+import { SongPreview, useMusicPlayer } from "@/stores/music-player";
 
 import AppPage from "@/components/AppPage.vue";
 import GenericSongItem from "@/components/GenericSongItem.vue";
@@ -31,7 +30,7 @@ const musicPlayer = useMusicPlayer();
 
 const searchTerm = ref("");
 const searchSuggestions = ref<string[]>([]);
-const searchResults = ref<SongSearchResult[]>([]);
+const searchResults = ref<SongPreview[]>([]);
 
 const offset = ref(0);
 const searched = ref(false);
@@ -79,23 +78,23 @@ async function loadMoreContent(event: InfiniteScrollCustomEvent): Promise<void> 
 	await event.target.complete();
 }
 
-async function playNow(searchResult: SongSearchResult<AnySong>): Promise<void> {
-	const song = await musicPlayer.services.getSongFromSearchResult(searchResult);
+async function playNow(searchResult: SongPreview): Promise<void> {
+	const song = await musicPlayer.services.getSongFromPreview(searchResult);
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex);
 }
 
-async function playNext(searchResult: SongSearchResult<AnySong>): Promise<void> {
-	const song = await musicPlayer.services.getSongFromSearchResult(searchResult);
+async function playNext(searchResult: SongPreview): Promise<void> {
+	const song = await musicPlayer.services.getSongFromPreview(searchResult);
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex + 1);
 }
 
-async function addToQueue(searchResult: SongSearchResult<AnySong>): Promise<void> {
-	const song = await musicPlayer.services.getSongFromSearchResult(searchResult);
+async function addToQueue(searchResult: SongPreview): Promise<void> {
+	const song = await musicPlayer.services.getSongFromPreview(searchResult);
 	await musicPlayer.state.addToQueue(song);
 }
 
 const router = useIonRouter();
-function goToSong(searchResult: SongSearchResult): void {
+function goToSong(searchResult: SongPreview): void {
 	if (!searchResult) return;
 	router.push(`/library/songs/${searchResult.type}/${searchResult.id}`);
 }

--- a/src/pages/Search/SearchPage.vue
+++ b/src/pages/Search/SearchPage.vue
@@ -20,17 +20,20 @@ import {
 } from "ionicons/icons";
 import { ref } from "vue";
 
-import { SongPreview, useMusicPlayer } from "@/stores/music-player";
+import { useMusicPlayer } from "@/stores/music-player";
 
 import AppPage from "@/components/AppPage.vue";
 import GenericSongItem from "@/components/GenericSongItem.vue";
 import SkeletonItem from "@/components/SkeletonItem.vue";
+import { Song, SongPreview } from "@/services/Music/objects";
 
 const musicPlayer = useMusicPlayer();
 
 const searchTerm = ref("");
 const searchSuggestions = ref<string[]>([]);
-const searchResults = ref<SongPreview[]>([]);
+
+type SearchResult = SongPreview | Song;
+const searchResults = ref<SearchResult[]>([]);
 
 const offset = ref(0);
 const searched = ref(false);
@@ -78,23 +81,23 @@ async function loadMoreContent(event: InfiniteScrollCustomEvent): Promise<void> 
 	await event.target.complete();
 }
 
-async function playNow(searchResult: SongPreview): Promise<void> {
-	const song = await musicPlayer.services.getSongFromPreview(searchResult);
+async function playNow(searchResult: SearchResult): Promise<void> {
+	const song = await musicPlayer.services.retrieveSong(searchResult);
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex);
 }
 
-async function playNext(searchResult: SongPreview): Promise<void> {
-	const song = await musicPlayer.services.getSongFromPreview(searchResult);
+async function playNext(searchResult: SearchResult): Promise<void> {
+	const song = await musicPlayer.services.retrieveSong(searchResult);
 	await musicPlayer.state.addToQueue(song, musicPlayer.state.queueIndex + 1);
 }
 
-async function addToQueue(searchResult: SongPreview): Promise<void> {
-	const song = await musicPlayer.services.getSongFromPreview(searchResult);
+async function addToQueue(searchResult: SearchResult): Promise<void> {
+	const song = await musicPlayer.services.retrieveSong(searchResult);
 	await musicPlayer.state.addToQueue(song);
 }
 
 const router = useIonRouter();
-function goToSong(searchResult: SongPreview): void {
+function goToSong(searchResult: SearchResult): void {
 	if (!searchResult) return;
 	router.push(`/library/songs/${searchResult.type}/${searchResult.id}`);
 }

--- a/src/pages/Search/SearchPage.vue
+++ b/src/pages/Search/SearchPage.vue
@@ -99,7 +99,7 @@ async function addToQueue(searchResult: SearchResult): Promise<void> {
 const router = useIonRouter();
 function goToSong(searchResult: SearchResult): void {
 	if (!searchResult) return;
-	router.push(`/library/songs/${searchResult.type}/${searchResult.id}`);
+	router.push(`/items/songs/${searchResult.type}/${searchResult.id}`);
 }
 </script>
 

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -23,24 +23,24 @@ const routes: RouteRecordRaw[] = [
 	{ path: "/library", name: "Library", component: LibraryPage },
 
 	{ path: "/library/songs", name: "Songs", component: SongsPage },
-	{ path: "/library/songs/:songType/:songId", name: "Song", component: SongPage },
+	{ path: "/items/songs/:songType/:songId", name: "Song", component: SongPage },
 
 	{ path: "/library/artists", name: "Artists", component: ArtistsPage },
-	{ path: "/library/artists/:artistType/:artistId", name: "Artist", component: ArtistPage },
+	{ path: "/items/artists/:artistType/:artistId", name: "Artist", component: ArtistPage },
 	{
-		path: "/library/artists/:artistType/:artistId/songs",
+		path: "/items/artists/:artistType/:artistId/songs",
 		name: "Artists Songs",
 		component: ArtistsSongsPage,
 	},
 
 	{ path: "/library/albums", name: "Albums", component: AlbumsPage },
 	// Album page provided as is
-	{ path: "/library/albums/album/:albumType/:albumId", name: "Album", component: AlbumPage },
+	{ path: "/items/albums/album/:albumType/:albumId", name: "Album", component: AlbumPage },
 	// Album page provided by song
-	{ path: "/library/albums/song/:songType/:songId", name: "Songs Album", component: AlbumPage },
+	{ path: "/items/albums/song/:songType/:songId", name: "Songs Album", component: AlbumPage },
 
 	{ path: "/library/playlists", name: "Playlists", component: PlaylistsPage },
-	{ path: "/library/playlists/:id", name: "Playlist", component: PlaylistPage },
+	{ path: "/items/playlists/:id", name: "Playlist", component: PlaylistPage },
 ];
 
 const router = createRouter({

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -18,13 +18,16 @@ const routes: RouteRecordRaw[] = [
 	{ path: "/search", name: "Search", component: SearchPage },
 
 	{ path: "/library", name: "Library", component: LibraryPage },
+
 	{ path: "/library/songs", name: "Songs", component: SongsPage },
 	{ path: "/library/songs/:songType/:songId", name: "Song", component: SongPage },
+
 	{ path: "/library/albums", name: "Albums", component: AlbumsPage },
 	// Album page provided as is
 	{ path: "/library/albums/album/:albumType/:albumId", name: "Album", component: AlbumPage },
 	// Album page provided by song
 	{ path: "/library/albums/song/:songType/:songId", name: "Songs Album", component: AlbumPage },
+
 	{ path: "/library/playlists", name: "Playlists", component: PlaylistsPage },
 	{ path: "/library/playlists/:id", name: "Playlist", component: PlaylistPage },
 ];

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -13,6 +13,7 @@ import PlaylistPage from "@/pages/Library/Playlists/Playlist/PlaylistPage.vue";
 import PlaylistsPage from "@/pages/Library/Playlists/PlaylistsPage.vue";
 import SongPage from "@/pages/Library/Songs/Song/SongPage.vue";
 import SongsPage from "@/pages/Library/Songs/SongsPage.vue";
+import ArtistsSongsPage from "./Library/Artists/Artist/ArtistsSongsPage.vue";
 
 const routes: RouteRecordRaw[] = [
 	{ path: "/", redirect: "/home" },
@@ -26,6 +27,11 @@ const routes: RouteRecordRaw[] = [
 
 	{ path: "/library/artists", name: "Artists", component: ArtistsPage },
 	{ path: "/library/artists/:artistType/:artistId", name: "Artist", component: ArtistPage },
+	{
+		path: "/library/artists/:artistType/:artistId/songs",
+		name: "Artists Songs",
+		component: ArtistsSongsPage,
+	},
 
 	{ path: "/library/albums", name: "Albums", component: AlbumsPage },
 	// Album page provided as is

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -6,12 +6,13 @@ import SearchPage from "@/pages/Search/SearchPage.vue";
 
 import AlbumPage from "@/pages/Library/Albums/Album/AlbumPage.vue";
 import AlbumsPage from "@/pages/Library/Albums/AlbumsPage.vue";
+import ArtistPage from "@/pages/Library/Artists/Artist/ArtistPage.vue";
+import ArtistsPage from "@/pages/Library/Artists/ArtistsPage.vue";
 import LibraryPage from "@/pages/Library/LibraryPage.vue";
 import PlaylistPage from "@/pages/Library/Playlists/Playlist/PlaylistPage.vue";
 import PlaylistsPage from "@/pages/Library/Playlists/PlaylistsPage.vue";
 import SongPage from "@/pages/Library/Songs/Song/SongPage.vue";
 import SongsPage from "@/pages/Library/Songs/SongsPage.vue";
-import ArtistsPage from "./Library/Artists/ArtistsPage.vue";
 
 const routes: RouteRecordRaw[] = [
 	{ path: "/", redirect: "/home" },
@@ -24,7 +25,7 @@ const routes: RouteRecordRaw[] = [
 	{ path: "/library/songs/:songType/:songId", name: "Song", component: SongPage },
 
 	{ path: "/library/artists", name: "Artists", component: ArtistsPage },
-	// { path: "/library/artists/:songType/:artistId", name: "Artist", component: SongPage },
+	{ path: "/library/artists/:artistType/:artistId", name: "Artist", component: ArtistPage },
 
 	{ path: "/library/albums", name: "Albums", component: AlbumsPage },
 	// Album page provided as is

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -24,7 +24,7 @@ const routes: RouteRecordRaw[] = [
 	// Album page provided as is
 	{ path: "/library/albums/album/:albumType/:albumId", name: "Album", component: AlbumPage },
 	// Album page provided by song
-	{ path: "/library/albums/song/:songType/:songId", name: "Album", component: AlbumPage },
+	{ path: "/library/albums/song/:songType/:songId", name: "Songs Album", component: AlbumPage },
 	{ path: "/library/playlists", name: "Playlists", component: PlaylistsPage },
 	{ path: "/library/playlists/:id", name: "Playlist", component: PlaylistPage },
 ];

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -11,6 +11,7 @@ import PlaylistPage from "@/pages/Library/Playlists/Playlist/PlaylistPage.vue";
 import PlaylistsPage from "@/pages/Library/Playlists/PlaylistsPage.vue";
 import SongPage from "@/pages/Library/Songs/Song/SongPage.vue";
 import SongsPage from "@/pages/Library/Songs/SongsPage.vue";
+import ArtistsPage from "./Library/Artists/ArtistsPage.vue";
 
 const routes: RouteRecordRaw[] = [
 	{ path: "/", redirect: "/home" },
@@ -21,6 +22,9 @@ const routes: RouteRecordRaw[] = [
 
 	{ path: "/library/songs", name: "Songs", component: SongsPage },
 	{ path: "/library/songs/:songType/:songId", name: "Song", component: SongPage },
+
+	{ path: "/library/artists", name: "Artists", component: ArtistsPage },
+	// { path: "/library/artists/:songType/:artistId", name: "Artist", component: SongPage },
 
 	{ path: "/library/albums", name: "Albums", component: AlbumsPage },
 	// Album page provided as is

--- a/src/pages/router.ts
+++ b/src/pages/router.ts
@@ -4,12 +4,13 @@ import { RouteRecordRaw } from "vue-router";
 import HomePage from "@/pages/Home/HomePage.vue";
 import SearchPage from "@/pages/Search/SearchPage.vue";
 
+import AlbumPage from "@/pages/Library/Albums/Album/AlbumPage.vue";
 import AlbumsPage from "@/pages/Library/Albums/AlbumsPage.vue";
 import LibraryPage from "@/pages/Library/LibraryPage.vue";
+import PlaylistPage from "@/pages/Library/Playlists/Playlist/PlaylistPage.vue";
 import PlaylistsPage from "@/pages/Library/Playlists/PlaylistsPage.vue";
+import SongPage from "@/pages/Library/Songs/Song/SongPage.vue";
 import SongsPage from "@/pages/Library/Songs/SongsPage.vue";
-import PlaylistPage from "./Library/Playlists/Playlist/PlaylistPage.vue";
-import SongPage from "./Library/Songs/Song/SongPage.vue";
 
 const routes: RouteRecordRaw[] = [
 	{ path: "/", redirect: "/home" },
@@ -18,8 +19,12 @@ const routes: RouteRecordRaw[] = [
 
 	{ path: "/library", name: "Library", component: LibraryPage },
 	{ path: "/library/songs", name: "Songs", component: SongsPage },
-	{ path: "/library/songs/:type/:id", name: "Song", component: SongPage },
+	{ path: "/library/songs/:songType/:songId", name: "Song", component: SongPage },
 	{ path: "/library/albums", name: "Albums", component: AlbumsPage },
+	// Album page provided as is
+	{ path: "/library/albums/album/:albumType/:albumId", name: "Album", component: AlbumPage },
+	// Album page provided by song
+	{ path: "/library/albums/song/:songType/:songId", name: "Album", component: AlbumPage },
 	{ path: "/library/playlists", name: "Playlists", component: PlaylistsPage },
 	{ path: "/library/playlists/:id", name: "Playlist", component: PlaylistPage },
 ];

--- a/src/services/Music/LocalMusicService.ts
+++ b/src/services/Music/LocalMusicService.ts
@@ -229,7 +229,7 @@ export class LocalMusicService extends MusicService<LocalSong> {
 		}
 	}
 
-	handleGetSongFromSearchResult(searchResult: LocalSong): LocalSong {
+	handleGetSongFromPreview(searchResult: LocalSong): LocalSong {
 		return searchResult;
 	}
 

--- a/src/services/Music/LocalMusicService.ts
+++ b/src/services/Music/LocalMusicService.ts
@@ -23,7 +23,8 @@ import {
 	ArtistKey,
 	ArtistPreview,
 	cache,
-	filledArtistPreview,
+	DisplayableArtist,
+	filledDisplayableArtist,
 	generateCacheMethod,
 	getAllCached,
 	getKey,
@@ -37,13 +38,11 @@ const getCached = generateCacheMethod("local");
 type LocalAlbum = Album<"local">;
 type LocalAlbumSong = AlbumSong<"local">;
 type _LocalArtist = Artist<"local">;
-type LocalArtistPreview<Full extends boolean = boolean> = ArtistPreview<"local", Full>;
+type _LocalArtistPreview = ArtistPreview<"local">;
 type _LocalArtistKey = ArtistKey<"local">;
 type LocalSong = Song<"local">;
 type LocalSongPreview = SongPreview<"local">;
-
-// const localSongs = useIDBKeyval<LocalSong[]>("localMusicSongs", []);
-// const albums = useIDBKeyval<LocalAlbum[]>("localAlbums", []);
+type LocalDisplayableArtist = DisplayableArtist<"local">;
 
 async function* getSongPaths(): AsyncGenerator<{ filePath: string; id?: string }> {
 	switch (getPlatform()) {
@@ -147,7 +146,7 @@ async function parseLocalSong(path: string, id: string): Promise<LocalSong> {
 
 	const { common, format } = metadata;
 
-	const artists: LocalArtistPreview[] = [];
+	const artists: LocalDisplayableArtist[] = [];
 	if (common.artists?.length) {
 		for (let i = 0; i < common.artists.length; ++i) {
 			const title = common.artists[i]!;
@@ -382,9 +381,9 @@ export class LocalMusicService extends MusicService<"local"> {
 				if (album.title !== song.album) return false;
 
 				return album.artists.some((artist) => {
-					const albumArtist = filledArtistPreview(artist);
+					const albumArtist = filledDisplayableArtist(artist);
 					return song.artists.find(
-						(songArtist) => filledArtistPreview(songArtist).title == albumArtist.title,
+						(songArtist) => filledDisplayableArtist(songArtist).title == albumArtist.title,
 					);
 				});
 			});

--- a/src/services/Music/LocalMusicService.ts
+++ b/src/services/Music/LocalMusicService.ts
@@ -124,6 +124,10 @@ async function parseLocalSong(buffer: Uint8Array, path: string, id: string): Pro
 	return {
 		type: "local",
 
+		available: true,
+		// TODO: Try to find a way to classify local files as explicit
+		explicit: false,
+
 		id,
 		artists,
 		album,

--- a/src/services/Music/LocalMusicService.ts
+++ b/src/services/Music/LocalMusicService.ts
@@ -418,7 +418,7 @@ export class LocalMusicService extends MusicService<"local"> {
 
 		const itemHasCurrentArtist = (itemArtist: LocalDisplayableArtist): boolean => {
 			const { title } = filledDisplayableArtist(itemArtist);
-			return title !== artist.title;
+			return title === artist.title;
 		};
 
 		for (const song of getAllCached<LocalSong>("local", "song")) {
@@ -432,8 +432,6 @@ export class LocalMusicService extends MusicService<"local"> {
 				artist.albums.push(getKey(album));
 			}
 		}
-
-		console.log(artist);
 
 		return cache(artist);
 	}

--- a/src/services/Music/MusicKitMusicService.ts
+++ b/src/services/Music/MusicKitMusicService.ts
@@ -79,6 +79,8 @@ export function musicKitSearchResult(
 
 	const artists = extractArtistNames(relationships?.artists?.data ?? attributes?.artistName);
 	const genres = extractGenres(relationships?.genres?.data ?? attributes?.genreNames);
+	const explicit = song.attributes?.contentRating === "explicit";
+	const available = typeof song.attributes?.playParams === "object";
 
 	return {
 		type: "musickit",
@@ -90,6 +92,9 @@ export function musicKitSearchResult(
 		duration: attributes?.durationInMillis && attributes?.durationInMillis / 1000,
 		genres,
 
+		explicit,
+		available,
+
 		artwork,
 	};
 }
@@ -97,7 +102,7 @@ export function musicKitSearchResult(
 export async function musicKitPreviewToSong(
 	searchResult: SongPreview<MusicKitSong>,
 ): Promise<MusicKitSong> {
-	const { id, artists, title, album, duration } = searchResult;
+	const { id, artists, title, album, duration, available = false, explicit = false } = searchResult;
 
 	const genres = searchResult.genres ?? [];
 	let artwork: Maybe<LocalImage>;
@@ -124,6 +129,9 @@ export async function musicKitPreviewToSong(
 		album,
 		duration,
 
+		explicit,
+		available,
+
 		artwork,
 		style: await generateSongStyle(artwork),
 
@@ -139,6 +147,8 @@ export async function musicKitSong(
 	const artwork = await extractArtwork(id, attributes?.artwork);
 	const artists = extractArtistNames(relationships?.artists?.data ?? attributes?.artistName);
 	const genres = extractGenres(relationships?.genres?.data ?? attributes?.genreNames);
+	const explicit = song.attributes?.contentRating === "explicit";
+	const available = typeof song.attributes?.playParams === "object";
 
 	let catalogId = id;
 	if (relationships && "catalog" in relationships) {
@@ -152,6 +162,9 @@ export async function musicKitSong(
 		id,
 		artists,
 		genres,
+
+		explicit,
+		available,
 
 		title: attributes?.name,
 		album: attributes?.albumName,

--- a/src/services/Music/MusicKitMusicService.ts
+++ b/src/services/Music/MusicKitMusicService.ts
@@ -21,6 +21,7 @@ import {
 	ArtistPreview,
 	cache,
 	DisplayableArtist,
+	Filled,
 	generateCacheMethod,
 	getKey,
 	Playlist,
@@ -474,18 +475,18 @@ export class MusicKitMusicService extends MusicService<"musickit"> {
 	// TODO: Make a unified way to handle pagination in MusicKit, that uses "next" instead of calculating it manually
 	#artistsSongsPagination: Record<ArtistId, { maxOffset?: number; pages: string[] }> = {};
 	async *handleGetArtistsSongs(
-		id: ArtistId,
+		artist: MusicKitArtist | Filled<MusicKitArtist>,
 		offset: number,
 		options?: { signal?: AbortSignal },
 	): AsyncGenerator<MusicKitSong | MusicKitSongPreview> {
-		const pagination = (this.#artistsSongsPagination[id] ??= { pages: [] });
+		const pagination = (this.#artistsSongsPagination[artist.id] ??= { pages: [] });
 
 		if (options?.signal?.aborted || (pagination.maxOffset && offset > pagination.maxOffset)) {
 			return;
 		}
 
 		const response = await this.music!.api.music<MusicKit.SongsResponse>(
-			`/v1/catalog/{{storefrontId}}/artists/${id}/view/top-songs`,
+			`/v1/catalog/{{storefrontId}}/artists/${artist.id}/view/top-songs`,
 			{ offset: offset * 25, limit: 25 },
 		);
 

--- a/src/services/Music/MusicKitMusicService.ts
+++ b/src/services/Music/MusicKitMusicService.ts
@@ -171,7 +171,17 @@ export async function musicKitAlbum(album: MusicKit.Albums): Promise<Album> {
 	const artwork = await extractArtwork(id, attributes?.artwork);
 	const artists = extractArtists(relationships?.artists?.data ?? attributes?.artistName);
 
-	const songs = relationships?.tracks?.data?.map(musicKitSearchResult) ?? [];
+	const songs: Album["songs"] = [];
+	const tracks = relationships?.tracks?.data;
+	if (tracks) {
+		for (const track of tracks) {
+			songs.push({
+				discNumber: track.attributes?.discNumber,
+				trackNumber: track.attributes?.trackNumber,
+				song: musicKitSearchResult(track),
+			});
+		}
+	}
 
 	return {
 		id: album.id,

--- a/src/services/Music/MusicKitMusicService.ts
+++ b/src/services/Music/MusicKitMusicService.ts
@@ -384,7 +384,7 @@ export class MusicKitMusicService extends MusicService<MusicKitSong> {
 			idType === "catalog"
 				? `/v1/catalog/{{storefrontId}}/songs/${songId}`
 				: `/v1/me/library/songs/${songId}`,
-			{ include: ["catalog"] },
+			{ include: ["artists", "catalog"] },
 		);
 
 		const [responseSong] = response.data.data;

--- a/src/services/Music/MusicKitMusicService.ts
+++ b/src/services/Music/MusicKitMusicService.ts
@@ -444,7 +444,7 @@ export class MusicKitMusicService extends MusicService<"musickit"> {
 
 	async *handleGetLibraryArtists(options?: {
 		signal?: AbortSignal;
-	}): AsyncGenerator<MusicKitArtistPreview> {
+	}): AsyncGenerator<MusicKitArtistPreview | MusicKitArtist> {
 		const response = await this.music!.api.music<
 			MusicKit.LibraryArtistsResponse,
 			MusicKit.LibraryArtistsQuery
@@ -457,7 +457,9 @@ export class MusicKitMusicService extends MusicService<"musickit"> {
 
 		for (const artist of artists) {
 			if (options?.signal?.aborted) return;
-			yield musicKitArtistPreview(artist);
+			yield getCached("artist", artist.id) ??
+				getCached("artistPreview", artist.id) ??
+				cache(musicKitArtistPreview(artist));
 		}
 	}
 
@@ -687,7 +689,9 @@ export class MusicKitMusicService extends MusicService<"musickit"> {
 			if (options?.signal?.aborted) {
 				return;
 			}
-			yield musicKitSongPreview(song);
+			yield getCached("song", song.id) ??
+				getCached("songPreview", song.id) ??
+				cache(musicKitSongPreview(song));
 		}
 	}
 

--- a/src/services/Music/MusicService.ts
+++ b/src/services/Music/MusicService.ts
@@ -18,8 +18,8 @@ import {
 	Album,
 	AlbumPreview,
 	Artist,
-	ArtistId,
 	ArtistPreview,
+	Filled,
 	Playlist,
 	Song,
 	SongPreview,
@@ -395,12 +395,12 @@ export abstract class MusicService<
 	}
 
 	handleGetArtistsSongs?(
-		id: ArtistId,
+		artist: Artist | Filled<Artist>,
 		offset: number,
 		options?: { signal?: AbortSignal },
 	): AsyncGenerator<Song<Type> | SongPreview<Type>>;
 	async *getArtistsSongs(
-		id: ArtistId,
+		artist: Artist | Filled<Artist>,
 		offset = 0,
 		options?: { signal?: AbortSignal },
 	): AsyncGenerator<Song<Type> | SongPreview<Type>> {
@@ -412,7 +412,7 @@ export abstract class MusicService<
 		const songs = await this.withErrorHandling(
 			undefined!,
 			this.handleGetArtistsSongs,
-			id,
+			artist,
 			offset,
 			options,
 		);

--- a/src/services/Music/MusicService.ts
+++ b/src/services/Music/MusicService.ts
@@ -18,6 +18,7 @@ import {
 	Album,
 	AlbumPreview,
 	Artist,
+	ArtistId,
 	ArtistPreview,
 	Playlist,
 	Song,
@@ -293,8 +294,12 @@ export abstract class MusicService<
 		localImages.deduplicate();
 	}
 
-	handleGetLibraryAlbums?(options?: { signal?: AbortSignal }): AsyncGenerator<AlbumPreview | Album>;
-	async *getLibraryAlbums(options?: { signal?: AbortSignal }): AsyncGenerator<AlbumPreview | Album> {
+	handleGetLibraryAlbums?(options?: {
+		signal?: AbortSignal;
+	}): AsyncGenerator<AlbumPreview<Type> | Album<Type>>;
+	async *getLibraryAlbums(options?: {
+		signal?: AbortSignal;
+	}): AsyncGenerator<AlbumPreview<Type> | Album<Type>> {
 		this.log("getLibraryAlbums");
 		if (!this.handleGetLibraryAlbums) {
 			throw new Error("This service does not support getLibraryAlbums");
@@ -318,10 +323,10 @@ export abstract class MusicService<
 
 	handleGetLibraryArtists?(options?: {
 		signal?: AbortSignal;
-	}): AsyncGenerator<ArtistPreview | Artist>;
+	}): AsyncGenerator<ArtistPreview<Type> | Artist<Type>>;
 	async *getLibraryArtists(options?: {
 		signal?: AbortSignal;
-	}): AsyncGenerator<ArtistPreview | Artist> {
+	}): AsyncGenerator<ArtistPreview<Type> | Artist<Type>> {
 		this.log("getLibraryArtists");
 		if (!this.handleGetLibraryArtists) {
 			throw new Error("This service does not support getLibraryArtists");
@@ -354,8 +359,8 @@ export abstract class MusicService<
 		return album;
 	}
 
-	handleGetAlbum?(id: string): Maybe<Album> | Promise<Maybe<Album>>;
-	async getAlbum(id: string): Promise<Maybe<Album>> {
+	handleGetAlbum?(id: string): Maybe<Album<Type>> | Promise<Maybe<Album<Type>>>;
+	async getAlbum(id: string): Promise<Maybe<Album<Type>>> {
 		this.log("getAlbum");
 		await this.initialize();
 
@@ -387,6 +392,33 @@ export abstract class MusicService<
 
 		const artist = await this.withErrorHandling(undefined, this.handleGetArtist, id);
 		return artist;
+	}
+
+	handleGetArtistsSongs?(
+		id: ArtistId,
+		offset: number,
+		options?: { signal?: AbortSignal },
+	): AsyncGenerator<Song<Type> | SongPreview<Type>>;
+	async *getArtistsSongs(
+		id: ArtistId,
+		offset = 0,
+		options?: { signal?: AbortSignal },
+	): AsyncGenerator<Song<Type> | SongPreview<Type>> {
+		this.log("getArtistsSongs");
+		if (!this.handleGetArtistsSongs) {
+			throw new Error("This service does not support getArtistsSongs");
+		}
+
+		const songs = await this.withErrorHandling(
+			undefined!,
+			this.handleGetArtistsSongs,
+			id,
+			offset,
+			options,
+		);
+		if (!songs) return;
+
+		yield* songs;
 	}
 
 	abstract handleGetSong(songId: string): Maybe<Song<Type>> | Promise<Maybe<Song<Type>>>;

--- a/src/services/Music/MusicService.ts
+++ b/src/services/Music/MusicService.ts
@@ -14,7 +14,16 @@ import { useMusicServices } from "@/stores/music-services";
 
 import { Maybe } from "@/utils/types";
 
-import { Album, AlbumPreview, Artist, Playlist, Song, SongPreview, SongType } from "./objects";
+import {
+	Album,
+	AlbumPreview,
+	Artist,
+	ArtistPreview,
+	Playlist,
+	Song,
+	SongPreview,
+	SongType,
+} from "./objects";
 
 export interface MusicServiceState {
 	enabled: boolean;
@@ -284,8 +293,8 @@ export abstract class MusicService<
 		localImages.deduplicate();
 	}
 
-	handleGetLibraryAlbums?(options?: { signal?: AbortSignal }): AsyncGenerator<AlbumPreview>;
-	async *getLibraryAlbums(options?: { signal?: AbortSignal }): AsyncGenerator<AlbumPreview> {
+	handleGetLibraryAlbums?(options?: { signal?: AbortSignal }): AsyncGenerator<AlbumPreview | Album>;
+	async *getLibraryAlbums(options?: { signal?: AbortSignal }): AsyncGenerator<AlbumPreview | Album> {
 		this.log("getLibraryAlbums");
 		if (!this.handleGetLibraryAlbums) {
 			throw new Error("This service does not support getLibraryAlbums");
@@ -305,6 +314,33 @@ export abstract class MusicService<
 		}
 
 		await this.withErrorHandling(undefined!, this.handleRefreshLibraryAlbums);
+	}
+
+	handleGetLibraryArtists?(options?: {
+		signal?: AbortSignal;
+	}): AsyncGenerator<ArtistPreview | Artist>;
+	async *getLibraryArtists(options?: {
+		signal?: AbortSignal;
+	}): AsyncGenerator<ArtistPreview | Artist> {
+		this.log("getLibraryArtists");
+		if (!this.handleGetLibraryArtists) {
+			throw new Error("This service does not support getLibraryArtists");
+		}
+
+		const artists = await this.withErrorHandling(undefined!, this.handleGetLibraryArtists, options);
+		if (!artists) return;
+
+		yield* artists;
+	}
+
+	handleRefreshLibraryArtists?(): void | Promise<void>;
+	async refreshLibraryArtists(): Promise<void> {
+		this.log("refreshLibraryArtists");
+		if (!this.handleRefreshLibraryArtists) {
+			throw new Error("This service does not support refreshLibraryArtists");
+		}
+
+		await this.withErrorHandling(undefined!, this.handleRefreshLibraryArtists);
 	}
 
 	handleGetSongsAlbum?(song: Song<Type>): Maybe<Album<Type>> | Promise<Maybe<Album<Type>>>;

--- a/src/services/Music/YouTubeMusicService.ts
+++ b/src/services/Music/YouTubeMusicService.ts
@@ -422,15 +422,6 @@ export class YouTubeMusicService extends MusicService<YouTubeSong> {
 		};
 	}
 
-	handleLibrarySongs(_offset: number): YouTubeSong[] {
-		// TODO: Implement local version of it
-		return [];
-	}
-
-	async handleRefreshLibrarySongs(): Promise<void> {
-		// TODO: Unimplemented
-	}
-
 	async handleGetSong(songId: string, cache = true): Promise<YouTubeSong> {
 		if (cache) {
 			const cachedSong = this.getCached<YouTubeSong>(songId);

--- a/src/services/Music/YouTubeMusicService.ts
+++ b/src/services/Music/YouTubeMusicService.ts
@@ -157,6 +157,7 @@ export async function youtubeAlbum(id: string, album: YTMusic.Album): Promise<Al
 	}
 
 	return {
+		type: "youtube",
 		id,
 		title,
 		artists,

--- a/src/services/Music/YouTubeMusicService.ts
+++ b/src/services/Music/YouTubeMusicService.ts
@@ -23,17 +23,21 @@ import {
 	Song,
 	SongKey,
 	SongPreview,
+	SongPreviewKey,
 } from "./objects";
 
 const getCached = generateCacheMethod("youtube");
 
 type YouTubeAlbum = Album<"youtube">;
+type YouTubeAlbumKey = AlbumKey<"youtube">;
 type YouTubeAlbumSong = AlbumSong<"youtube">;
 type YouTubeArtist = Artist<"youtube">;
 type _YouTubeArtistPreview = ArtistPreview<"youtube">;
 type _YouTubeArtistKey = ArtistKey<"youtube">;
 type YouTubeSong = Song<"youtube">;
+type YouTubeSongKey = SongKey<"youtube">;
 type YouTubeSongPreview<HasId extends boolean = false> = SongPreview<"youtube", HasId>;
+type YouTubeSongPreviewKey = SongPreviewKey<"youtube">;
 type YoutubeDisplayableArtist = DisplayableArtist<"youtube">;
 
 export function youtubeSongPreview(
@@ -100,8 +104,6 @@ export async function youtubeSong(
 	searchResult?: YouTubeSongPreview,
 ): Promise<YouTubeSong> {
 	const { id, title, duration, thumbnail } = trackInfo.basic_info;
-
-	console.log(title, trackInfo, searchResult);
 
 	if (!id) {
 		throw new Error("Cannot generate YouTubeSong from trackInfo that doesn't have id");
@@ -476,8 +478,8 @@ export class YouTubeMusicService extends MusicService<"youtube"> {
 		const artist = await this.innertube!.music.getArtist(id);
 		const title = artist.header?.title?.toString() ?? "Unknown title";
 
-		const songs: SongKey[] = [];
-		const albums: AlbumKey[] = [];
+		const songs: (YouTubeSongKey | YouTubeSongPreviewKey)[] = [];
+		const albums: YouTubeAlbumKey[] = [];
 
 		for (const section of artist.sections) {
 			if (!section.is(YTNodes.MusicCarouselShelf)) continue;

--- a/src/services/Music/objects/album.ts
+++ b/src/services/Music/objects/album.ts
@@ -6,7 +6,6 @@ import type { SongKey, SongPreview, SongPreviewKey, SongType } from "./song";
 
 export type AlbumId = string;
 export type AlbumKey<Type extends SongType = SongType> = ItemKey<Album<Type>>;
-
 export interface Album<Type extends SongType = SongType> extends Identifiable {
 	type: Type;
 	id: AlbumId;
@@ -19,6 +18,7 @@ export interface Album<Type extends SongType = SongType> extends Identifiable {
 	songs: AlbumSong<Type>[];
 }
 
+export type AlbumPreviewKey<Type extends SongType = SongType> = ItemKey<AlbumPreview<Type>>;
 export type AlbumPreview<Type extends SongType = SongType> = Identifiable &
 	Partial<Omit<Album<Type>, "kind">> & {
 		type: Type;

--- a/src/services/Music/objects/album.ts
+++ b/src/services/Music/objects/album.ts
@@ -72,7 +72,7 @@ export function filledAlbum(album: Album): Filled<Album> {
 
 			const cached = getCachedFromKey(artist);
 			if (!cached) {
-				throw new Error(`Album tried to retrieve artist ${cached}, but it is not cached`);
+				throw new Error(`Album tried to retrieve artist ${artist}, but it is not cached`);
 			}
 			return cached;
 		}),

--- a/src/services/Music/objects/album.ts
+++ b/src/services/Music/objects/album.ts
@@ -1,0 +1,84 @@
+import type { LocalImage } from "@/stores/local-images";
+import { filledArtistPreview, type Artist, type ArtistPreview } from "./artist";
+import { getCachedFromKey } from "./cache";
+import { type Filled, type Identifiable, type ItemKey } from "./shared";
+import type { SongKey, SongPreview, SongPreviewKey, SongType } from "./song";
+
+export type AlbumId = string;
+export type AlbumKey = ItemKey<Album>;
+
+export interface Album<Type extends SongType = SongType> extends Identifiable {
+	type: Type;
+	id: AlbumId;
+	kind: "album";
+
+	title: string;
+	artwork?: LocalImage;
+
+	artists: ArtistPreview<Type>[];
+	songs: AlbumSong<Type>[];
+}
+
+export type AlbumPreview<Type extends SongType = SongType> =
+	| Album<Type>
+	| (Identifiable &
+			Partial<Omit<Album<Type>, "kind">> & {
+				type: Type;
+				id: AlbumId;
+				kind: "albumPreview";
+
+				title: string;
+				artists: ArtistPreview<Type>[];
+			});
+
+export interface AlbumSong<Type extends SongType = SongType> {
+	discNumber?: number;
+	trackNumber?: number;
+	song: SongKey<Type> | SongPreviewKey<Type> | SongPreview<Type, false>;
+}
+
+export function filledAlbumSong(albumSong: AlbumSong): Filled<AlbumSong> {
+	let song;
+	if (typeof albumSong.song === "object") {
+		song = {
+			...albumSong.song,
+			artists: albumSong.song.artists.map(filledArtistPreview),
+		};
+	} else {
+		song = getCachedFromKey(albumSong.song);
+		if (!song) {
+			const err = new Error(`Album tried to retrieve song ${albumSong.song}, but it is not cached`);
+			console.error(err);
+			throw err;
+		}
+	}
+
+	return {
+		song,
+		discNumber: albumSong.discNumber,
+		trackNumber: albumSong.trackNumber,
+	};
+}
+
+export function filledAlbum(album: Album): Filled<Album> {
+	return {
+		type: album.type,
+		id: album.id,
+		kind: "album",
+
+		title: album.title,
+		artwork: album.artwork,
+
+		artists: album.artists.map((artist) => {
+			if (typeof artist === "object") return artist;
+			const cached = getCachedFromKey<Artist>(artist);
+			if (!cached) {
+				const err = new Error(`Album tried to retrieve artist ${artist}, but it is not cached`);
+				console.error(err);
+				throw err;
+			}
+			return cached;
+		}),
+		songs: album.songs.map(filledAlbumSong),
+	};
+}

--- a/src/services/Music/objects/album.ts
+++ b/src/services/Music/objects/album.ts
@@ -5,7 +5,7 @@ import { type Filled, type Identifiable, type ItemKey } from "./shared";
 import type { SongKey, SongPreview, SongPreviewKey, SongType } from "./song";
 
 export type AlbumId = string;
-export type AlbumKey = ItemKey<Album>;
+export type AlbumKey<Type extends SongType = SongType> = ItemKey<Album<Type>>;
 
 export interface Album<Type extends SongType = SongType> extends Identifiable {
 	type: Type;

--- a/src/services/Music/objects/artist.ts
+++ b/src/services/Music/objects/artist.ts
@@ -1,8 +1,8 @@
 import type { LocalImage } from "@/stores/local-images";
-import type { AlbumKey } from "./album";
+import type { AlbumKey, AlbumPreviewKey } from "./album";
 import { getCachedFromKey } from "./cache";
 import { Filled, type Identifiable, type ItemKey } from "./shared";
-import type { SongKey, SongType } from "./song";
+import type { SongKey, SongPreviewKey, SongType } from "./song";
 
 export type ArtistId = string;
 export type ArtistKey<Type extends SongType = SongType> = ItemKey<Artist<Type>>;
@@ -14,8 +14,8 @@ export interface Artist<Type extends SongType = SongType> extends Identifiable {
 	title: string;
 	artwork?: LocalImage;
 
-	albums: AlbumKey<Type>[];
-	songs: SongKey<Type>[];
+	albums: (AlbumPreviewKey<Type> | AlbumKey<Type>)[];
+	songs: (SongKey<Type> | SongPreviewKey<Type>)[];
 }
 
 export type ArtistPreviewKey<Type extends SongType = SongType> = ItemKey<ArtistPreview<Type>>;

--- a/src/services/Music/objects/artist.ts
+++ b/src/services/Music/objects/artist.ts
@@ -14,8 +14,8 @@ export interface Artist<Type extends SongType = SongType> extends Identifiable {
 	title: string;
 	artwork?: LocalImage;
 
-	albums: AlbumKey[];
-	songs: SongKey[];
+	albums: AlbumKey<Type>[];
+	songs: SongKey<Type>[];
 }
 
 export type ArtistPreviewKey<Type extends SongType = SongType> = ItemKey<ArtistPreview<Type>>;
@@ -38,7 +38,9 @@ export type DisplayableArtist<Type extends SongType = SongType> =
 	| ArtistPreview<Type>
 	| InlineArtist;
 
-export function filledDisplayableArtist(artist: DisplayableArtist): Filled<DisplayableArtist> {
+export function filledDisplayableArtist<Type extends SongType = SongType>(
+	artist: DisplayableArtist<Type>,
+): Filled<DisplayableArtist<Type>> {
 	if (typeof artist === "object") {
 		return artist;
 	}

--- a/src/services/Music/objects/artist.ts
+++ b/src/services/Music/objects/artist.ts
@@ -1,0 +1,43 @@
+import type { LocalImage } from "@/stores/local-images";
+import type { AlbumKey } from "./album";
+import { getCachedFromKey } from "./cache";
+import { Filled, type Identifiable, type ItemKey } from "./shared";
+import type { SongKey, SongType } from "./song";
+
+export type ArtistId = string;
+export type ArtistKey<Type extends SongType = SongType> = ItemKey<Artist<Type>>;
+
+export interface Artist<Type extends SongType = SongType> extends Identifiable {
+	type: Type;
+	id: ArtistId;
+	kind: "artist";
+
+	title: string;
+	artwork?: LocalImage;
+
+	albums: AlbumKey[];
+	songs: SongKey[];
+}
+
+export type ArtistPreview<
+	Type extends SongType = SongType,
+	Full extends true | false = true | false,
+> =
+	| Artist<Type>
+	| (Full extends true ? ArtistKey<Type> : { id?: ArtistId; title: string; artwork?: LocalImage });
+
+export function filledArtistPreview<Type extends SongType>(
+	artist: ArtistPreview<Type>,
+): Filled<ArtistPreview<Type>> {
+	if (typeof artist === "object") {
+		return artist;
+	}
+
+	const cached = getCachedFromKey<Artist>(artist);
+	if (!cached) {
+		const err = new Error(`Tried to retrieve artist ${artist}, but it is not cached`);
+		console.error(err);
+		throw err;
+	}
+	return cached;
+}

--- a/src/services/Music/objects/artist.ts
+++ b/src/services/Music/objects/artist.ts
@@ -47,7 +47,7 @@ export function filledDisplayableArtist<Type extends SongType = SongType>(
 
 	const cached = getCachedFromKey(artist);
 	if (!cached) {
-		throw new Error(`Artist tried to retrieve cached ${cached}, but it is not cached`);
+		throw new Error(`Artist tried to retrieve cached ${artist}, but it is not cached`);
 	}
 	return cached;
 }

--- a/src/services/Music/objects/cache.ts
+++ b/src/services/Music/objects/cache.ts
@@ -11,6 +11,8 @@ import { Song, SongPreview, SongType } from "./song";
 // TODO: In the future it would be a good idea to use more organised cache storage
 // 		 Since it is possible to categorise items by their id, type and kind
 //       Which would make querying the data much more efficient
+// TODO: Add a way to dynamically retrieve data that IS NOT cached but
+// 		 some other item has it linked, e.g. useMusicServices().retrieveKey(...)
 export const itemCache = useIDBKeyval<Record<ItemKey<any>, Identifiable>>("itemCache", {});
 
 export function generateCacheMethod<const Type extends SongType>(type: Type) {
@@ -49,6 +51,10 @@ export function cache<Item extends Identifiable>(item: Item | Promise<Item>): It
 
 export function removeFromCache(item: Identifiable): boolean {
 	return delete itemCache.data.value[getKey(item)];
+}
+
+export function clearCache(): void {
+	itemCache.data.value = {};
 }
 
 export function* getAllCached<Item extends Identifiable>(

--- a/src/services/Music/objects/cache.ts
+++ b/src/services/Music/objects/cache.ts
@@ -41,7 +41,7 @@ export function cache<Item extends Identifiable>(item: Item | Promise<Item>): It
 	if (item instanceof Promise) {
 		return item.then((item) => {
 			itemCache.data.value[getKey(item)] = item;
-			return item;
+			return markRaw(item);
 		});
 	}
 

--- a/src/services/Music/objects/cache.ts
+++ b/src/services/Music/objects/cache.ts
@@ -3,7 +3,7 @@ import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { createKey, getKey, Identifiable, ItemKey, unpackKey } from "./shared";
 
 import { Maybe } from "@/utils/types";
-import { markRaw, toRaw } from "vue";
+import { markRawDeep } from "@/utils/vue";
 import { Album, AlbumPreview } from "./album";
 import { Artist, ArtistPreview } from "./artist";
 import { Song, SongPreview, SongType } from "./song";
@@ -13,7 +13,11 @@ import { Song, SongPreview, SongType } from "./song";
 //       Which would make querying the data much more efficient
 // TODO: Add a way to dynamically retrieve data that IS NOT cached but
 // 		 some other item has it linked, e.g. useMusicServices().retrieveKey(...)
-export const itemCache = useIDBKeyval<Record<ItemKey<any>, Identifiable>>("itemCache", {});
+export const itemCache = useIDBKeyval<Record<ItemKey<any>, Identifiable>>(
+	"itemCache",
+	{},
+	{ deep: false },
+);
 
 export function generateCacheMethod<const Type extends SongType>(type: Type) {
 	interface ItemMap {
@@ -41,12 +45,12 @@ export function cache<Item extends Identifiable>(item: Item | Promise<Item>): It
 	if (item instanceof Promise) {
 		return item.then((item) => {
 			itemCache.data.value[getKey(item)] = item;
-			return markRaw(item);
+			return markRawDeep(item);
 		});
 	}
 
 	itemCache.data.value[getKey(item)] = item;
-	return markRaw(item);
+	return markRawDeep(item);
 }
 
 export function removeFromCache(item: Identifiable): boolean {
@@ -74,7 +78,7 @@ export function getCached<Item extends Identifiable>(
 	kind: Item["kind"],
 ): Maybe<Item> {
 	const item = itemCache.data.value[createKey(type, id, kind)];
-	return toRaw(item) as Maybe<Item>;
+	return item as Maybe<Item>;
 }
 
 export function getCachedFromKey<Item extends Identifiable>(key: ItemKey<Item>): Maybe<Item> {

--- a/src/services/Music/objects/cache.ts
+++ b/src/services/Music/objects/cache.ts
@@ -1,0 +1,72 @@
+import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
+
+import { createKey, getKey, Identifiable, ItemKey, unpackKey } from "./shared";
+
+import { Maybe } from "@/utils/types";
+import { markRaw, toRaw } from "vue";
+import { Album } from "./album";
+import { Artist } from "./artist";
+import { Song, SongPreview, SongType } from "./song";
+
+// TODO: In the future it would be a good idea to use more organised cache storage
+// 		 Since it is possible to categorise items by their id, type and kind
+//       Which would make querying the data much more efficient
+export const itemCache = useIDBKeyval<Record<ItemKey<any>, Identifiable>>("itemCache", {});
+
+export function generateCacheMethod<const Type extends SongType>(type: Type) {
+	interface ItemMap {
+		album: Album<Type>;
+		artist: Artist<Type>;
+		song: Song<Type>;
+		songPreview: SongPreview<Type, true>;
+	}
+
+	type ItemMapKey = keyof ItemMap;
+
+	return <const Kind extends ItemMapKey>(
+		kind: Kind & ItemMap[Kind]["kind"],
+		id: ItemMap[Kind]["id"],
+	): Maybe<ItemMap[Kind]> => getCached(type as ItemMap[Kind]["type"], id, kind);
+}
+
+export function cache<Item extends Identifiable>(item: Promise<Item>): Promise<Item>;
+export function cache<Item extends Identifiable>(item: Item): Item;
+export function cache<Item extends Identifiable>(item: Item | Promise<Item>): Item | Promise<Item> {
+	if (item instanceof Promise) {
+		return item.then((item) => {
+			itemCache.data.value[getKey(item)] = item;
+			return item;
+		});
+	}
+
+	itemCache.data.value[getKey(item)] = item;
+	return markRaw(item);
+}
+
+export function removeFromCache(item: Identifiable): boolean {
+	return delete itemCache.data.value[getKey(item)];
+}
+
+export function* getAllCached<Item extends Identifiable>(
+	type: Item["type"],
+	kind: Item["kind"],
+): Generator<Item> {
+	for (const item of Object.values(itemCache.data.value)) {
+		if (item.type === type && item.kind === kind) {
+			yield item as Item;
+		}
+	}
+}
+
+export function getCached<Item extends Identifiable>(
+	type: Item["type"],
+	id: Item["id"],
+	kind: Item["kind"],
+): Maybe<Item> {
+	const item = itemCache.data.value[createKey(type, id, kind)];
+	return toRaw(item) as Maybe<Item>;
+}
+
+export function getCachedFromKey<Item extends Identifiable>(key: ItemKey<Item>): Maybe<Item> {
+	return getCached(...unpackKey(key));
+}

--- a/src/services/Music/objects/cache.ts
+++ b/src/services/Music/objects/cache.ts
@@ -4,8 +4,8 @@ import { createKey, getKey, Identifiable, ItemKey, unpackKey } from "./shared";
 
 import { Maybe } from "@/utils/types";
 import { markRaw, toRaw } from "vue";
-import { Album } from "./album";
-import { Artist } from "./artist";
+import { Album, AlbumPreview } from "./album";
+import { Artist, ArtistPreview } from "./artist";
 import { Song, SongPreview, SongType } from "./song";
 
 // TODO: In the future it would be a good idea to use more organised cache storage
@@ -16,7 +16,9 @@ export const itemCache = useIDBKeyval<Record<ItemKey<any>, Identifiable>>("itemC
 export function generateCacheMethod<const Type extends SongType>(type: Type) {
 	interface ItemMap {
 		album: Album<Type>;
+		albumPreview: AlbumPreview<Type>;
 		artist: Artist<Type>;
+		artistPreview: ArtistPreview<Type>;
 		song: Song<Type>;
 		songPreview: SongPreview<Type, true>;
 	}
@@ -29,7 +31,9 @@ export function generateCacheMethod<const Type extends SongType>(type: Type) {
 	): Maybe<ItemMap[Kind]> => getCached(type as ItemMap[Kind]["type"], id, kind);
 }
 
-export function cache<Item extends Identifiable>(item: Promise<Item>): Promise<Item>;
+export function cache<ItemPromise extends Promise<Identifiable>>(
+	item: ItemPromise,
+): Awaited<ItemPromise>;
 export function cache<Item extends Identifiable>(item: Item): Item;
 export function cache<Item extends Identifiable>(item: Item | Promise<Item>): Item | Promise<Item> {
 	if (item instanceof Promise) {

--- a/src/services/Music/objects/index.ts
+++ b/src/services/Music/objects/index.ts
@@ -1,0 +1,6 @@
+export * from "./album";
+export * from "./artist";
+export * from "./cache";
+export * from "./playlist";
+export * from "./shared";
+export * from "./song";

--- a/src/services/Music/objects/playlist.ts
+++ b/src/services/Music/objects/playlist.ts
@@ -1,0 +1,41 @@
+import { LocalImage } from "@/stores/local-images";
+import type { Identifiable } from "../MusicService";
+import { getCachedFromKey } from "./cache";
+import { Filled } from "./shared";
+import type { SongKey } from "./song";
+
+// TODO: Support in-place playlists on MusicKit
+type PlaylistType = "unimusic";
+type PlaylistId = string;
+
+export interface Playlist<Type extends PlaylistType = PlaylistType> extends Identifiable {
+	type: Type;
+	id: PlaylistId;
+	kind: "playlist";
+
+	title: string;
+	artwork?: LocalImage;
+
+	songs: SongKey[];
+}
+
+export function filledPlaylist(playlist: Playlist): Filled<Playlist> {
+	return {
+		type: playlist.type,
+		id: playlist.id,
+		kind: "playlist",
+
+		title: playlist.title,
+		artwork: playlist.artwork,
+
+		songs: playlist.songs.map((song) => {
+			const cached = getCachedFromKey(song);
+			if (!cached) {
+				const err = new Error(`Playlist tried to retrieve song ${song}, but it is not cached`);
+				console.error(err);
+				throw err;
+			}
+			return cached;
+		}),
+	};
+}

--- a/src/services/Music/objects/shared.ts
+++ b/src/services/Music/objects/shared.ts
@@ -1,0 +1,59 @@
+const PHANTOM_TYPE_DATA = Symbol("PHANTOM_TYPE_DATA");
+
+type Primitive = string | number | boolean;
+
+export interface Identifiable {
+	type: Primitive;
+	kind: Primitive;
+	id: Primitive;
+}
+
+export type ItemKey<T extends Identifiable> = `${T["type"]}/${T["id"]}` & {
+	[PHANTOM_TYPE_DATA]?: T;
+};
+
+// If Type is an union, it becomes union of two filled parts
+export type FilledUnion<Type> = Type extends infer A | infer B
+	? Filled<A> | Filled<B>
+	: Filled<Type>;
+
+export type Filled<Type> =
+	// If Type is an ItemKey, it becomes an item the key poinst to
+	Type extends ItemKey<infer Item extends Identifiable>
+		? Item
+		: { [key in keyof Type]: FilledUnion<Type[key]> };
+
+export function createKey<Item extends Identifiable>(
+	type: Item["type"],
+	id: Item["id"],
+	kind: Item["kind"],
+): ItemKey<Item> {
+	type = encodeURIComponent(type);
+	id = encodeURIComponent(id);
+	kind = kind && encodeURIComponent(kind);
+	return kind ? (`${type}/${id}/${kind}` as const) : (`${type}/${id}` as const);
+}
+
+export function isKey(key: string): key is ItemKey<any> {
+	const data = key.split("/");
+	if (data.length < 2 || data.length > 3) return false;
+	return true;
+}
+
+export function unpackKey<Item extends Identifiable>(
+	key: ItemKey<Item>,
+): [type: Item["type"], id: Item["id"], kind: Item["kind"]] {
+	const data = key.split("/");
+	if (data.length !== 3) {
+		throw new Error(`Tried unpacking invalid key: ${key}`);
+	}
+
+	const type = decodeURIComponent(data[0]!);
+	const id = decodeURIComponent(data[1]!);
+	const kind = decodeURIComponent(data[2]!);
+	return [type, id, kind];
+}
+
+export function getKey<Item extends Identifiable>(item: Item): ItemKey<Item> {
+	return createKey(item.type, item.id, item.kind);
+}

--- a/src/services/Music/objects/song.ts
+++ b/src/services/Music/objects/song.ts
@@ -1,5 +1,5 @@
 import type { LocalImage } from "@/stores/local-images";
-import { filledArtistPreview, type ArtistPreview } from "./artist";
+import { DisplayableArtist, filledDisplayableArtist } from "./artist";
 import type { Filled, Identifiable, ItemKey } from "./shared";
 
 type SongTypes = {
@@ -20,7 +20,7 @@ export type Song<Type extends SongType = SongType> = Identifiable & {
 	available: boolean;
 	explicit: boolean;
 
-	artists: ArtistPreview<Type>[];
+	artists: DisplayableArtist<Type>[];
 	genres: string[];
 
 	title?: string;
@@ -43,28 +43,14 @@ export type SongPreview<Type extends SongType = SongType, HasId extends boolean 
 				id?: SongId;
 				kind: "songPreview";
 
-				artists: ArtistPreview<Type>[];
+				artists: DisplayableArtist<Type>[];
 				genres: string[];
 			});
 
 export function filledSong(song: Song): Filled<Song> {
 	return {
 		...song,
-
-		type: song.type,
-		id: song.id,
 		kind: "song",
-
-		available: song.available,
-		explicit: song.explicit,
-
-		artists: song.artists.map(filledArtistPreview),
-		genres: song.genres,
-
-		title: song.title,
-		album: song.album,
-		duration: song.duration,
-		artwork: song.artwork,
-		style: song.style,
+		artists: song.artists.map(filledDisplayableArtist),
 	};
 }

--- a/src/services/Music/objects/song.ts
+++ b/src/services/Music/objects/song.ts
@@ -1,0 +1,70 @@
+import type { LocalImage } from "@/stores/local-images";
+import { filledArtistPreview, type ArtistPreview } from "./artist";
+import type { Filled, Identifiable, ItemKey } from "./shared";
+
+type SongTypes = {
+	youtube: { albumId?: string };
+	musickit: { catalogId?: string };
+	local: { path: string; discNumber?: number; trackNumber?: number };
+};
+
+export type SongType = "youtube" | "musickit" | "local";
+export type SongId = string;
+export type SongKey<Type extends SongType = SongType> = ItemKey<Song<Type>>;
+
+export type Song<Type extends SongType = SongType> = Identifiable & {
+	type: Type;
+	id: SongId;
+	kind: "song";
+
+	available: boolean;
+	explicit: boolean;
+
+	artists: ArtistPreview<Type>[];
+	genres: string[];
+
+	title?: string;
+	album?: string;
+	duration?: number;
+	artwork?: LocalImage;
+	// TODO: Move this to LocalImage, and use the background color as a fallback
+	style: { fgColor: string; bgColor: string; bgGradient: string };
+
+	data: SongTypes[Type];
+};
+
+export type SongPreviewKey<Type extends SongType = SongType> = ItemKey<SongPreview<Type, true>>;
+
+export type SongPreview<Type extends SongType = SongType, HasId extends boolean = false> =
+	| Song<Type>
+	| ((HasId extends true ? Identifiable : Record<never, never>) &
+			Partial<Omit<Song<Type>, "kind">> & {
+				type: Type;
+				id?: SongId;
+				kind: "songPreview";
+
+				artists: ArtistPreview<Type>[];
+				genres: string[];
+			});
+
+export function filledSong(song: Song): Filled<Song> {
+	return {
+		...song,
+
+		type: song.type,
+		id: song.id,
+		kind: "song",
+
+		available: song.available,
+		explicit: song.explicit,
+
+		artists: song.artists.map(filledArtistPreview),
+		genres: song.genres,
+
+		title: song.title,
+		album: song.album,
+		duration: song.duration,
+		artwork: song.artwork,
+		style: song.style,
+	};
+}

--- a/src/services/Music/objects/song.ts
+++ b/src/services/Music/objects/song.ts
@@ -4,7 +4,7 @@ import type { Filled, Identifiable, ItemKey } from "./shared";
 
 type SongTypes = {
 	youtube: { albumId?: string };
-	musickit: { catalogId?: string };
+	musickit: { catalogId?: string; musicVideo?: boolean };
 	local: { path: string; discNumber?: number; trackNumber?: number; isrc?: string[] };
 };
 

--- a/src/services/Music/objects/song.ts
+++ b/src/services/Music/objects/song.ts
@@ -5,7 +5,7 @@ import type { Filled, Identifiable, ItemKey } from "./shared";
 type SongTypes = {
 	youtube: { albumId?: string };
 	musickit: { catalogId?: string };
-	local: { path: string; discNumber?: number; trackNumber?: number };
+	local: { path: string; discNumber?: number; trackNumber?: number; isrc?: string[] };
 };
 
 export type SongType = "youtube" | "musickit" | "local";

--- a/src/stores/local-images.ts
+++ b/src/stores/local-images.ts
@@ -1,4 +1,4 @@
-import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval";
+import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { defineStore } from "pinia";
 
 import { EitherType, Maybe } from "@/utils/types";

--- a/src/stores/metadata.ts
+++ b/src/stores/metadata.ts
@@ -1,4 +1,4 @@
-import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval";
+import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { defineStore } from "pinia";
 import { toRaw } from "vue";
 

--- a/src/stores/metadata.ts
+++ b/src/stores/metadata.ts
@@ -2,13 +2,10 @@ import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { defineStore } from "pinia";
 import { toRaw } from "vue";
 
-import { AnySong, Song } from "@/stores/music-player";
-
+import { Song, SongType } from "@/services/Music/objects";
 import { Maybe } from "@/utils/types";
 
-type MetadataOverride = {
-	[key in Exclude<keyof AnySong, "id" | "type">]?: AnySong[key];
-};
+export type MetadataOverride = Omit<Song, "id" | "type" | "kind" | "data" | "available">;
 
 export const useSongMetadata = defineStore("SongMetadata", () => {
 	const overrides = useIDBKeyval<Record<string, Maybe<MetadataOverride>>>("metadataOverrides", {});
@@ -21,11 +18,11 @@ export const useSongMetadata = defineStore("SongMetadata", () => {
 		overrides.data.value[id] = toRaw(metadata);
 	}
 
-	function applyMetadata<T extends Song<string> = AnySong>(
-		song: T,
+	function applyMetadata<Type extends SongType>(
+		song: Song<Type>,
 		metadata = getSongMetadata(song.id),
-	): T {
-		return Object.assign(song, metadata satisfies Maybe<Partial<AnySong>>);
+	): Song<Type> {
+		return Object.assign(song, metadata satisfies Maybe<Partial<Song>>);
 	}
 
 	return {

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -64,18 +64,21 @@ export interface Playlist {
 }
 
 export interface DiscSong {
-	discNumber?: number | string;
-	trackNumber?: number | string;
+	discNumber?: number;
+	trackNumber?: number;
 	song: SongPreview;
 }
 
 export interface Album {
+	type: AnySong["type"];
 	id: string;
 	title: string;
 	artwork?: LocalImage;
 	artists: Artist[];
 	songs: DiscSong[];
 }
+
+export type AlbumPreview = Pick<Album, "id" | "type" | "title" | "artwork" | "artists">;
 
 export const useMusicPlayer = defineStore("MusicPlayer", () => {
 	const localImages = useLocalImages();

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -46,7 +46,7 @@ export type SongPreview<Song extends AnySong = AnySong> = Pick<Song, "type" | "i
 
 export type MusicKitSong = Song<"musickit", { catalogId: string }>;
 export type YouTubeSong = Song<"youtube", { albumId?: string }>;
-export type LocalSong = Song<"local", { path: string }>;
+export type LocalSong = Song<"local", { path: string; discNumber?: number; trackNumber?: number }>;
 
 export type AnySong = MusicKitSong | YouTubeSong | LocalSong;
 

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -45,7 +45,7 @@ export type SongPreview<Song extends AnySong = AnySong> = Pick<Song, "type" | "i
 	Partial<Song>;
 
 export type MusicKitSong = Song<"musickit", { catalogId: string }>;
-export type YouTubeSong = Song<"youtube">;
+export type YouTubeSong = Song<"youtube", { albumId?: string }>;
 export type LocalSong = Song<"local", { path: string }>;
 
 export type AnySong = MusicKitSong | YouTubeSong | LocalSong;

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -1,84 +1,16 @@
 import { defineStore, storeToRefs } from "pinia";
 import { computed, watch } from "vue";
 
-import { LocalImage, useLocalImages } from "@/stores/local-images";
+import { useLocalImages } from "@/stores/local-images";
 import { useMusicServices } from "@/stores/music-services";
 import { useMusicPlayerState } from "@/stores/music-state";
 
 import type { MusicService } from "@/services/Music/MusicService";
 
+import { filledArtistPreview } from "@/services/Music/objects";
 import { getPlatform } from "@/utils/os";
 import { formatArtists } from "@/utils/songs";
 import { Maybe } from "@/utils/types";
-
-export interface Artist {
-	id?: string;
-	name: string;
-}
-
-export interface Song<Type extends string, Data = unknown> {
-	type: Type;
-
-	id: string;
-
-	available: boolean;
-	explicit: boolean;
-
-	artists: string[];
-	genres: string[];
-
-	title?: string;
-	album?: string;
-	duration?: number;
-
-	artwork?: LocalImage;
-	style: {
-		fgColor: string;
-		bgColor: string;
-		bgGradient: string;
-	};
-
-	data: Data;
-}
-
-export type SongPreview<Song extends AnySong = AnySong> = Pick<Song, "type" | "id" | "artists"> &
-	Partial<Song>;
-
-export type MusicKitSong = Song<"musickit", { catalogId: string }>;
-export type YouTubeSong = Song<"youtube", { albumId?: string }>;
-export type LocalSong = Song<"local", { path: string; discNumber?: number; trackNumber?: number }>;
-
-export type AnySong = MusicKitSong | YouTubeSong | LocalSong;
-
-export interface Playlist {
-	id: string;
-	title: string;
-	artwork?: LocalImage;
-	songs: AnySong[];
-
-	importInfo?: {
-		id: string;
-		type: AnySong["type"];
-		info?: string;
-	};
-}
-
-export interface DiscSong {
-	discNumber?: number;
-	trackNumber?: number;
-	song: SongPreview;
-}
-
-export interface Album {
-	type: AnySong["type"];
-	id: string;
-	title: string;
-	artwork?: LocalImage;
-	artists: Artist[];
-	songs: DiscSong[];
-}
-
-export type AlbumPreview = Pick<Album, "id" | "type" | "title" | "artwork" | "artists">;
 
 export const useMusicPlayer = defineStore("MusicPlayer", () => {
 	const localImages = useLocalImages();
@@ -190,7 +122,7 @@ export const useMusicPlayer = defineStore("MusicPlayer", () => {
 						hasSkipForward: false,
 
 						track: currentSong?.title ?? "",
-						artist: formatArtists(currentSong?.artists),
+						artist: formatArtists(currentSong?.artists?.map(filledArtistPreview)),
 						album: currentSong?.album ?? "",
 
 						// FIXME: Local artworks
@@ -264,7 +196,7 @@ export const useMusicPlayer = defineStore("MusicPlayer", () => {
 
 			navigator.mediaSession.metadata = new window.MediaMetadata({
 				title: song.title,
-				artist: formatArtists(song.artists),
+				artist: formatArtists(song.artists.map(filledArtistPreview)),
 				album: song.album,
 				artwork: typeof artworkUrl === "string" ? [{ src: artworkUrl }] : undefined,
 			});

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -21,6 +21,9 @@ export interface Song<Type extends string, Data = unknown> {
 
 	id: string;
 
+	available: boolean;
+	explicit: boolean;
+
 	artists: string[];
 	genres: string[];
 

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -11,6 +11,11 @@ import { getPlatform } from "@/utils/os";
 import { formatArtists } from "@/utils/songs";
 import { Maybe } from "@/utils/types";
 
+export interface Artist {
+	id?: string;
+	name: string;
+}
+
 export interface Song<Type extends string, Data = unknown> {
 	type: Type;
 
@@ -33,7 +38,10 @@ export interface Song<Type extends string, Data = unknown> {
 	data: Data;
 }
 
-export type MusicKitSong = Song<"musickit">;
+export type SongPreview<Song extends AnySong = AnySong> = Pick<Song, "type" | "id" | "artists"> &
+	Partial<Song>;
+
+export type MusicKitSong = Song<"musickit", { catalogId: string }>;
 export type YouTubeSong = Song<"youtube">;
 export type LocalSong = Song<"local", { path: string }>;
 
@@ -41,14 +49,23 @@ export type AnySong = MusicKitSong | YouTubeSong | LocalSong;
 
 export interface Playlist {
 	id: string;
+	title: string;
+	artwork?: LocalImage;
+	songs: AnySong[];
+
 	importInfo?: {
 		id: string;
 		type: AnySong["type"];
 		info?: string;
 	};
+}
+
+export interface Album {
+	id: string;
 	title: string;
 	artwork?: LocalImage;
-	songs: AnySong[];
+	artists: Artist[];
+	songs: SongPreview[];
 }
 
 export const useMusicPlayer = defineStore("MusicPlayer", () => {
@@ -71,7 +88,6 @@ export const useMusicPlayer = defineStore("MusicPlayer", () => {
 	});
 
 	// Automatically change songs
-
 	let abortController = new AbortController();
 	watch(currentQueueSong, async () => {
 		abortController.abort();

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -7,7 +7,6 @@ import { useMusicPlayerState } from "@/stores/music-state";
 
 import type { MusicService } from "@/services/Music/MusicService";
 
-import { filledArtistPreview } from "@/services/Music/objects";
 import { getPlatform } from "@/utils/os";
 import { formatArtists } from "@/utils/songs";
 import { Maybe } from "@/utils/types";
@@ -122,7 +121,7 @@ export const useMusicPlayer = defineStore("MusicPlayer", () => {
 						hasSkipForward: false,
 
 						track: currentSong?.title ?? "",
-						artist: formatArtists(currentSong?.artists?.map(filledArtistPreview)),
+						artist: formatArtists(currentSong?.artists),
 						album: currentSong?.album ?? "",
 
 						// FIXME: Local artworks
@@ -196,7 +195,7 @@ export const useMusicPlayer = defineStore("MusicPlayer", () => {
 
 			navigator.mediaSession.metadata = new window.MediaMetadata({
 				title: song.title,
-				artist: formatArtists(song.artists.map(filledArtistPreview)),
+				artist: formatArtists(song.artists),
 				album: song.album,
 				artwork: typeof artworkUrl === "string" ? [{ src: artworkUrl }] : undefined,
 			});

--- a/src/stores/music-player.ts
+++ b/src/stores/music-player.ts
@@ -60,12 +60,18 @@ export interface Playlist {
 	};
 }
 
+export interface DiscSong {
+	discNumber?: number | string;
+	trackNumber?: number | string;
+	song: SongPreview;
+}
+
 export interface Album {
 	id: string;
 	title: string;
 	artwork?: LocalImage;
 	artists: Artist[];
-	songs: SongPreview[];
+	songs: DiscSong[];
 }
 
 export const useMusicPlayer = defineStore("MusicPlayer", () => {

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -61,7 +61,7 @@ export const useMusicServices = defineStore("MusicServices", () => {
 
 	async function* libraryAlbums(): AsyncGenerator<AlbumPreview> {
 		for (const service of enabledServices.value) {
-			if (!service.handleGetLibraryAlbums) return;
+			if (!service.handleGetLibraryAlbums) continue;
 			yield* service.getLibraryAlbums();
 		}
 	}

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -11,6 +11,7 @@ import {
 	Album,
 	AlbumPreview,
 	Artist,
+	ArtistId,
 	ArtistPreview,
 	Song,
 	SongPreview,
@@ -131,6 +132,13 @@ export const useMusicServices = defineStore("MusicServices", () => {
 	async function getArtist(type: Song["type"], id: string): Promise<Maybe<Artist>> {
 		return await getService(type)?.getArtist(id);
 	}
+
+	async function* getArtistsSongs(id: ArtistId, offset: number): AsyncGenerator<Song | SongPreview> {
+		for (const service of enabledServices.value) {
+			if (!service.handleGetArtistsSongs) continue;
+			yield* service.getArtistsSongs(id, offset);
+		}
+	}
 	// #endregion
 
 	registerService(new MusicKitMusicService());
@@ -163,6 +171,7 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		getSongsAlbum,
 
 		getArtist,
+		getArtistsSongs,
 		libraryArtists,
 		refreshLibraryArtists,
 	};

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -11,8 +11,8 @@ import {
 	Album,
 	AlbumPreview,
 	Artist,
-	ArtistId,
 	ArtistPreview,
+	Filled,
 	Song,
 	SongPreview,
 } from "@/services/Music/objects";
@@ -133,11 +133,14 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		return await getService(type)?.getArtist(id);
 	}
 
-	async function* getArtistsSongs(id: ArtistId, offset: number): AsyncGenerator<Song | SongPreview> {
-		for (const service of enabledServices.value) {
-			if (!service.handleGetArtistsSongs) continue;
-			yield* service.getArtistsSongs(id, offset);
-		}
+	async function* getArtistsSongs(
+		artist: Artist | Filled<Artist>,
+		offset: number,
+	): AsyncGenerator<Song | SongPreview> {
+		const service = getService(artist.type);
+		if (!service?.handleGetArtistsSongs) return;
+
+		yield* service.getArtistsSongs(artist, offset);
 	}
 	// #endregion
 

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -7,7 +7,7 @@ import { LocalMusicService } from "@/services/Music/LocalMusicService";
 import { MusicKitMusicService } from "@/services/Music/MusicKitMusicService";
 import { YouTubeMusicService } from "@/services/Music/YouTubeMusicService";
 
-import { Album, AnySong, SongPreview } from "@/stores/music-player";
+import { Album, AlbumPreview, AnySong, SongPreview } from "@/stores/music-player";
 
 import { Maybe } from "@/utils/types";
 
@@ -59,6 +59,20 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		await withAllServices((service) => service.refreshLibrarySongs());
 	}
 
+	async function* libraryAlbums(): AsyncGenerator<AlbumPreview> {
+		for (const service of enabledServices.value) {
+			if (!service.handleGetLibraryAlbums) return;
+			yield* service.getLibraryAlbums();
+		}
+	}
+
+	async function refreshLibraryAlbums(): Promise<void> {
+		await withAllServices((service) => {
+			if (!service.handleRefreshLibraryAlbums) return;
+			return service.refreshLibraryAlbums();
+		});
+	}
+
 	async function refreshSong(song: AnySong): Promise<Maybe<AnySong>> {
 		return await getService(song.type)?.refreshSong(song);
 	}
@@ -94,14 +108,19 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		getService,
 
 		withAllServices,
+
 		searchHints,
 		searchSongs,
+
+		getSong,
+		refreshSong,
+		getSongFromPreview,
 		librarySongs,
 		refreshLibrarySongs,
-		refreshSong,
-		getSong,
-		getSongFromPreview,
+
 		getAlbum,
+		libraryAlbums,
+		refreshLibraryAlbums,
 		getSongsAlbum,
 	};
 });

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -50,9 +50,11 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		}
 	}
 
-	async function librarySongs(offset = 0): Promise<AnySong[]> {
-		const allSongs = await withAllServices((service) => service.librarySongs(offset));
-		return allSongs.flat();
+	async function* librarySongs(offset = 0): AsyncGenerator<AnySong> {
+		for (const service of enabledServices.value) {
+			if (!service.handleGetLibrarySongs) continue;
+			yield* service.getLibrarySongs(offset);
+		}
 	}
 
 	async function refreshLibrarySongs(): Promise<void> {

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -58,7 +58,9 @@ export const useMusicServices = defineStore("MusicServices", () => {
 	}
 
 	async function refreshLibrarySongs(): Promise<void> {
-		await withAllServices((service) => service.refreshLibrarySongs());
+		await withAllServices((service) => {
+			return service.handleRefreshLibrarySongs && service.refreshLibrarySongs();
+		});
 	}
 
 	async function* libraryAlbums(): AsyncGenerator<AlbumPreview> {
@@ -70,8 +72,7 @@ export const useMusicServices = defineStore("MusicServices", () => {
 
 	async function refreshLibraryAlbums(): Promise<void> {
 		await withAllServices((service) => {
-			if (!service.handleRefreshLibraryAlbums) return;
-			return service.refreshLibraryAlbums();
+			return service.handleRefreshLibraryAlbums && service.refreshLibraryAlbums();
 		});
 	}
 

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -7,7 +7,14 @@ import { LocalMusicService } from "@/services/Music/LocalMusicService";
 import { MusicKitMusicService } from "@/services/Music/MusicKitMusicService";
 import { YouTubeMusicService } from "@/services/Music/YouTubeMusicService";
 
-import { Album, AlbumPreview, Artist, Song, SongPreview } from "@/services/Music/objects";
+import {
+	Album,
+	AlbumPreview,
+	Artist,
+	ArtistPreview,
+	Song,
+	SongPreview,
+} from "@/services/Music/objects";
 import { Maybe } from "@/utils/types";
 
 export const useMusicServices = defineStore("MusicServices", () => {
@@ -62,7 +69,7 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		});
 	}
 
-	async function* libraryAlbums(): AsyncGenerator<AlbumPreview> {
+	async function* libraryAlbums(): AsyncGenerator<AlbumPreview | Album> {
 		for (const service of enabledServices.value) {
 			if (!service.handleGetLibraryAlbums) continue;
 			yield* service.getLibraryAlbums();
@@ -72,6 +79,19 @@ export const useMusicServices = defineStore("MusicServices", () => {
 	async function refreshLibraryAlbums(): Promise<void> {
 		await withAllServices((service) => {
 			return service.handleRefreshLibraryAlbums && service.refreshLibraryAlbums();
+		});
+	}
+
+	async function* libraryArtists(): AsyncGenerator<ArtistPreview | Artist> {
+		for (const service of enabledServices.value) {
+			if (!service.handleGetLibraryArtists) continue;
+			yield* service.getLibraryArtists();
+		}
+	}
+
+	async function refreshLibraryArtists(): Promise<void> {
+		await withAllServices((service) => {
+			return service.handleRefreshLibraryArtists && service.refreshLibraryArtists();
 		});
 	}
 
@@ -143,5 +163,7 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		getSongsAlbum,
 
 		getArtist,
+		libraryArtists,
+		refreshLibraryArtists,
 	};
 });

--- a/src/stores/music-services.ts
+++ b/src/stores/music-services.ts
@@ -1,13 +1,13 @@
 import { defineStore } from "pinia";
 import { computed, reactive } from "vue";
 
-import { MusicService, SongSearchResult } from "@/services/Music/MusicService";
+import { MusicService } from "@/services/Music/MusicService";
 
 import { LocalMusicService } from "@/services/Music/LocalMusicService";
 import { MusicKitMusicService } from "@/services/Music/MusicKitMusicService";
 import { YouTubeMusicService } from "@/services/Music/YouTubeMusicService";
 
-import { AnySong } from "@/stores/music-player";
+import { Album, AnySong, SongPreview } from "@/stores/music-player";
 
 import { Maybe } from "@/utils/types";
 
@@ -44,7 +44,7 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		term: string,
 		offset = 0,
 		options?: { signal: AbortSignal },
-	): AsyncGenerator<SongSearchResult> {
+	): AsyncGenerator<SongPreview> {
 		for (const service of enabledServices.value) {
 			yield* service.searchSongs(term, offset, options);
 		}
@@ -63,14 +63,22 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		return await getService(song.type)?.refreshSong(song);
 	}
 
-	async function getSongFromSearchResult(searchResult: SongSearchResult): Promise<AnySong> {
+	async function getSongFromPreview(searchResult: SongPreview): Promise<AnySong> {
 		const service = getService(searchResult.type)!;
-		const song = await service.getSongFromSearchResult(searchResult);
+		const song = await service.getSongFromPreview(searchResult);
 		return song;
 	}
 
 	async function getSong(type: AnySong["type"], id: string): Promise<Maybe<AnySong>> {
 		return await getService(type)?.getSong(id);
+	}
+
+	async function getAlbum(type: AnySong["type"], id: string): Promise<Maybe<Album>> {
+		return await getService(type)?.getAlbum(id);
+	}
+
+	async function getSongsAlbum(song: AnySong): Promise<Maybe<Album>> {
+		return await getService(song.type)?.getSongsAlbum(song);
 	}
 	// #endregion
 
@@ -92,6 +100,8 @@ export const useMusicServices = defineStore("MusicServices", () => {
 		refreshLibrarySongs,
 		refreshSong,
 		getSong,
-		getSongFromSearchResult,
+		getSongFromPreview,
+		getAlbum,
+		getSongsAlbum,
 	};
 });

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -1,7 +1,7 @@
 import { useLocalStorage } from "@vueuse/core";
 import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { defineStore } from "pinia";
-import { computed, ref, toRaw } from "vue";
+import { computed, ref, shallowRef, toRaw, watch } from "vue";
 
 import { Playlist, Song } from "@/services/Music/objects";
 import { generateUUID } from "@/utils/crypto";
@@ -42,7 +42,16 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 		set: (value) => ($queue.data.value = value),
 	});
 	const queueIndex = useLocalStorage("queueIndex", 0);
-	const currentQueueSong = computed<Maybe<QueueSong>>(() => queue.value[queueIndex.value]);
+
+	const currentQueueSong = shallowRef<QueueSong>();
+	watch(
+		[queue, queueIndex],
+		([queue, queueIndex]) => {
+			currentQueueSong.value = queue[queueIndex];
+		},
+		{ deep: true },
+	);
+
 	const currentSong = computed<Maybe<Song>>(() => currentQueueSong.value?.song);
 
 	function songToQueueSong(song: Song): QueueSong {

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -3,15 +3,14 @@ import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { defineStore } from "pinia";
 import { computed, ref, toRaw } from "vue";
 
-import type { AnySong, Playlist } from "@/stores/music-player";
-
+import { Playlist, Song } from "@/services/Music/objects";
 import { generateUUID } from "@/utils/crypto";
 import { Maybe } from "@/utils/types";
 import { useLoadingCounter } from "@/utils/vue";
 
 interface QueueSong {
 	id: string;
-	song: AnySong;
+	song: Song;
 }
 
 export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
@@ -44,16 +43,14 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 	});
 	const queueIndex = useLocalStorage("queueIndex", 0);
 	const currentQueueSong = computed<Maybe<QueueSong>>(() => queue.value[queueIndex.value]);
-	const currentSong = computed<Maybe<AnySong>>(() => currentQueueSong.value?.song);
+	const currentSong = computed<Maybe<Song>>(() => currentQueueSong.value?.song);
 
-	function songToQueueSong(song: AnySong): QueueSong {
-		return {
-			id: generateUUID(),
-			song: toRaw(song),
-		};
+	function songToQueueSong(song: Song): QueueSong {
+		return { id: generateUUID(), song: toRaw(song) };
 	}
 
-	function setQueue(songs: AnySong[]): void {
+	function setQueue(songs: Song[]): void {
+		console.log(songs);
 		queue.value = songs.map(songToQueueSong);
 	}
 
@@ -62,12 +59,12 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 		queue.value.sort(() => Math.random() - 0.5);
 	}
 
-	async function addToQueue(song: AnySong, index = queue.value.length): Promise<void> {
+	async function addToQueue(song: Song, index = queue.value.length): Promise<void> {
 		queue.value.splice(index, 0, songToQueueSong(song));
 		await loadingCounters.queueChange.onLoaded();
 	}
 
-	async function insertIntoQueue(songs: AnySong[], index = queue.value.length): Promise<void> {
+	async function insertIntoQueue(songs: Song[], index = queue.value.length): Promise<void> {
 		queue.value.splice(index, 0, ...songs.map(songToQueueSong));
 		await loadingCounters.queueChange.onLoaded();
 	}

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -57,8 +57,18 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 		queue.value = songs.map(songToQueueSong);
 	}
 
+	function shuffleQueue(): void {
+		// TODO: Add a way to "smart shuffle" a queue, trying to omit having songs from the same album in a row
+		queue.value.sort(() => Math.random() - 0.5);
+	}
+
 	async function addToQueue(song: AnySong, index = queue.value.length): Promise<void> {
 		queue.value.splice(index, 0, songToQueueSong(song));
+		await loadingCounters.queueChange.onLoaded();
+	}
+
+	async function insertIntoQueue(songs: AnySong[], index = queue.value.length): Promise<void> {
+		queue.value.splice(index, 0, ...songs.map(songToQueueSong));
 		await loadingCounters.queueChange.onLoaded();
 	}
 
@@ -136,7 +146,9 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 		currentQueueSong,
 		currentSong,
 		setQueue,
+		shuffleQueue,
 		addToQueue,
+		insertIntoQueue,
 		removeFromQueue,
 		moveQueueItem,
 

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -50,7 +50,6 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 	}
 
 	function setQueue(songs: Song[]): void {
-		console.log(songs);
 		queue.value = songs.map(songToQueueSong);
 	}
 

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -41,7 +41,12 @@ export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 		get: () => $queue.data.value,
 		set: (value) => ($queue.data.value = value),
 	});
-	const queueIndex = useLocalStorage("queueIndex", 0);
+
+	const $queueIndex = useLocalStorage("queueIndex", 0);
+	const queueIndex = computed<number>({
+		get: () => $queueIndex.value,
+		set: (value) => ($queueIndex.value = Math.max(0, Math.min(value, queue.value.length - 1))),
+	});
 
 	const currentQueueSong = shallowRef<QueueSong>();
 	watch(

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -1,5 +1,5 @@
 import { useLocalStorage } from "@vueuse/core";
-import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval";
+import { useIDBKeyval } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { defineStore } from "pinia";
 import { computed, ref, toRaw } from "vue";
 

--- a/src/stores/music-state.ts
+++ b/src/stores/music-state.ts
@@ -16,23 +16,24 @@ interface QueueSong {
 
 export const useMusicPlayerState = defineStore("MusicPlayerState", () => {
 	// #region Playlist
-	const $playlists = useIDBKeyval<Playlist[]>("playlists", []);
+	const $playlists = useIDBKeyval<Record<string, Playlist>>("playlists", {});
 	const playlists = computed(() => $playlists.data.value);
 
 	function addPlaylist(playlist: Playlist): void {
-		playlists.value.push(playlist);
+		playlists.value[playlist.id] = playlist;
 	}
 
 	function removePlaylist(id: string): void {
-		const index = playlists.value.findIndex((playlist) => playlist.id === id);
-		if (index !== -1) {
-			playlists.value.splice(index, 1);
-		}
+		delete playlists.value[id];
 	}
 
 	function getPlaylist(id: string): Maybe<Playlist> {
-		return playlists.value.find((playlist) => playlist.id === id);
+		return playlists.value[id];
 	}
+	// #endregion
+
+	// #region Album
+
 	// #endregion
 
 	// #region Queue

--- a/src/types/musickit/album.ts
+++ b/src/types/musickit/album.ts
@@ -1,0 +1,141 @@
+declare global {
+	namespace MusicKit {
+		interface AlbumsQuery {
+			/** Additional relationships to include in the fetch. */
+			include?: (keyof AlbumsRelationships)[];
+			/** The localization to use, specified by a language tag. The possible values are in the supportedLanguageTags array belonging to the Storefront object specified by storefront. Otherwise, the default is defaultLanguageTag in Storefront. */
+			l?: string;
+			/** The views to activate for the resource. */
+			views?: string[];
+			/** A list of attribute extensions to apply to resources in the response. */
+			extend?: string[];
+		}
+
+		interface AlbumsRelationships {
+			/**
+			 * The curator that created the playlist. By default, curator includes identifiers only.
+			 * Fetch limits: none
+			 */
+			artists: AlbumsArtistsRelationships;
+			/**
+			 * The songs and music videos included in the playlist. By default, tracks includes objects.
+			 * Fetch limits: 300 default, 300 maximum
+			 */
+			tracks: AlbumsTracksRelationships;
+		}
+
+		/**
+		 * The response to a albums request.
+		 * @see https://developer.apple.com/documentation/applemusicapi/playlistsresponse
+		 */
+		interface AlbumsResponse {
+			/** The Albums included in the response for the request. */
+			data: Albums[];
+		}
+
+		/**
+		 * A resource object that represents an album.
+		 * @see https://developer.apple.com/documentation/applemusicapi/albums-uib
+		 */
+		interface Albums {
+			/** The identifier for the album. */
+			id: string;
+			/** This value is always albums. */
+			type: "albums";
+			/** The relative location for the album resource. */
+			href: string;
+			/** The attributes for the album. */
+			attributes?: AlbumsAttributes;
+
+			/** The relationships for the album. */
+			relationships?: AlbumsRelationships;
+			/** The relationship views for the album. */
+			views?: MusicKit.ResourceViews;
+		}
+
+		interface AlbumsAttributes {
+			/** The name of the primary artist associated with the album. */
+			artistName: string;
+			/** The URL of the artist for this content. */
+			artistUrl?: string;
+			/** The artwork for the album. */
+			artwork: Artwork;
+			/** Indicates the specific audio variant for the album. */
+			audioVariants?: AudioVariant[];
+			/** The Recording Industry Association of America (RIAA) rating of the content. No value means no rating. */
+			contentRating?: ContentRating;
+			/** The copyright text. */
+			copyright?: string;
+			/** The names of the genres associated with the album. */
+			genreNames: string[];
+			/** Indicates whether the album is marked as a compilation. If true, the album is a compilation; otherwise, it's not. */
+			isCompilation: boolean;
+			/** Indicates whether the album is complete. If true, the album is complete; otherwise, it's not. An album is complete if it contains all its tracks and songs. */
+			isComplete: boolean;
+			/** Indicates whether the album contains a single song. */
+			isSingle: boolean;
+			/** The localized name of the album. */
+			name: string;
+			/** When present, this attribute indicates that one or more tracks on the album are available to play with an Apple Music subscription. The value map may be used to initiate playback of available tracks on the album. */
+			playParams?: PlayParameters;
+			/** The name of the record label for the album. */
+			recordLabel?: string;
+			/** The release date of the album, when known, in YYYY-MM-DD or YYYY format. Prerelease content may have an expected release date in the future. */
+			releaseDate?: string;
+			/** The number of tracks for the album. */
+			trackCount: number;
+			/** The Universal Product Code for the album. */
+			upc?: string;
+			/** The URL for sharing the album in Apple Music. */
+			url?: string;
+		}
+	}
+
+	/**
+	 * The relationships for an album resource.
+	 * @see https://developer.apple.com/documentation/applemusicapi/albums/relationships-data.dictionary
+	 */
+	interface AlbumsRelationships {
+		/**
+		 * The artists associated with the album. By default, artists includes identifiers only.
+		 * Fetch limits: 10 default, 10 maximum
+		 */
+		artists: AlbumsArtistsRelationships;
+		/**
+		 * The songs and music videos included in the playlist. By default, tracks includes objects.
+		 * Fetch limits: 300 default, 300 maximum
+		 */
+		tracks: AlbumsTracksRelationships;
+	}
+
+	/**
+	 * A relationship from the album to its artists.
+	 * @see https://developer.apple.com/documentation/applemusicapi/albums/relationships-data.dictionary/albumsartistsrelationship
+	 */
+	interface AlbumsArtistsRelationships {
+		/* A relative location for the relationship. */
+		href?: string;
+		/* The relative location to request the next page of resources in the collection, if additional resources are available for fetching. */
+		next?: string;
+		/** The artists for the album. */
+		data: MusicKit.Artists[];
+	}
+
+	/**
+	 * A relationship from the album to its tracks.
+	 * @see https://developer.apple.com/documentation/applemusicapi/albums/relationships-data.dictionary/albumstracksrelationship
+	 */
+	interface AlbumsTracksRelationships {
+		/* A relative location for the relationship. */
+		href?: string;
+		/* The relative location to request the next page of resources in the collection, if additional resources are available for fetching. */
+		next?: string;
+		/**
+		 * The ordered songs and music videos in the tracklist of the album.
+		 * Possible types: MusicVideos, Songs
+		 */
+		data: MusicKit.Songs[];
+	}
+}
+
+export {};

--- a/src/types/musickit/artist.ts
+++ b/src/types/musickit/artist.ts
@@ -15,7 +15,7 @@ declare global {
 			attributes?: ArtistsAttributes;
 
 			/** The relationships for the artist. */
-			relationships?: MusicKit.ResourceRelationships;
+			relationships?: ArtistsRelationships;
 			/** The relationship views for the artist. */
 			views?: MusicKit.ResourceViews;
 		}
@@ -33,6 +33,52 @@ declare global {
 			name: string;
 			/** The URL for sharing the artist in Apple Music. */
 			url: string;
+		}
+
+		/**
+		 * The relationships for an artist resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/artistsresponse
+		 */
+		interface ArtistsRelationships {
+			/**
+			 * The albums associated with the artist. By default, albums includes identifiers only.
+			 * Fetch limits: 25 default, 100 maximum
+			 */
+			albums: ArtistsAlbumsRelationship;
+		}
+
+		/**
+		 * @see https://developer.apple.com/documentation/applemusicapi/artistsresponse
+		 */
+		interface ArtistsAlbumsRelationship {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/**
+			 * The albums for the artist.
+			 */
+			data: MusicKit.Albums[];
+		}
+
+		interface ArtistsQuery {
+			/** Additional relationships to include in the fetch. */
+			include?: (keyof ArtistsRelationships)[];
+			/** The localization to use, specified by a language tag. The possible values are in the supportedLanguageTags array belonging to the Storefront object specified by storefront. Otherwise, the default is defaultLanguageTag in Storefront. */
+			l?: string;
+			/** The views to activate for the resource. */
+			views?: string[];
+			/** A list of attribute extensions to apply to resources in the response. */
+			extend?: string[];
+		}
+
+		/**
+		 * The response to a  artists request.
+		 * @see https://developer.apple.com/documentation/applemusicapi/artistsresponse
+		 */
+		interface ArtistsResponse {
+			/** The LibraryArtists included in the response for the request. */
+			data: Artists[];
 		}
 
 		/**

--- a/src/types/musickit/artist.ts
+++ b/src/types/musickit/artist.ts
@@ -1,0 +1,147 @@
+declare global {
+	namespace MusicKit {
+		/**
+		 * A resource object that represents the artist of an album where an artist can be one or more people.
+		 * @see https://developer.apple.com/documentation/applemusicapi/artists-uip
+		 */
+		interface Artists {
+			/** The identifier for the artist. */
+			id: string;
+			/** This value is always artists. */
+			type: "artists";
+			/** The relative location for the artist resource. */
+			href: string;
+			/** The attributes for the artist. */
+			attributes?: ArtistsAttributes;
+
+			/** The relationships for the artist. */
+			relationships?: MusicKit.ResourceRelationships;
+			/** The relationship views for the artist. */
+			views?: MusicKit.ResourceViews;
+		}
+
+		/**
+		 * The attributes for an artist resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/artists/attributes
+		 */
+		interface ArtistsAttributes {
+			/** The artwork for the artist image. */
+			artwork?: Artwork;
+			/** The names of the genres associated with this artist. */
+			genreNames: string[];
+			/** The localized name of the artist. */
+			name: string;
+			/** The URL for sharing the artist in Apple Music. */
+			url: string;
+		}
+
+		/**
+		 * A resource object that represents an artist present in a user’s library.
+		 * @see https://developer.apple.com/documentation/applemusicapi/libraryartists
+		 */
+		interface LibraryArtists {
+			/** The identifier for the artist. */
+			id: string;
+			/** This value is always artists. */
+			type: "library-artists";
+			/** The relative location for the artist resource. */
+			href: string;
+			/** The attributes for the artist. */
+			attributes?: LibraryArtistsAttributes;
+
+			/** The relationships for the artist. */
+			relationships?: LibraryArtistsRelationships;
+		}
+
+		/**
+		 * The attributes for a library artist resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/libraryartists/attributes-data.dictionary
+		 */
+		interface LibraryArtistsAttributes {
+			/** The artist’s name. */
+			name: string;
+		}
+
+		/**
+		 * The relationships for a library artist resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/libraryartists/relationships-data.dictionary
+		 */
+		interface LibraryArtistsRelationships {
+			/**
+			 * The library albums associated with the artist. By default, albums not included. It’s available only when fetching a single library artist resource by ID.
+			 * Fetch limits: 25 default, 100 maximum
+			 */
+			albums?: LibraryArtistsAlbumsRelationship;
+			/**
+			 * The artist in the Apple Music catalog the library artist is associated with, when known.
+			 * Fetch limits: None (associated with, at most, one catalog artist).
+			 */
+			catalog?: LibraryArtistsCatalogRelationship;
+		}
+
+		/**
+		 * A relationship from the library artist to their albums.
+		 * @see https://developer.apple.com/documentation/applemusicapi/libraryartists/relationships-data.dictionary/libraryartistsalbumsrelationship
+		 */
+		interface LibraryArtistsAlbumsRelationship {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/**
+			 * The albums for the library artist present in the user’s library.
+			 */
+			data: MusicKit.Albums[];
+		}
+
+		/**
+		 * A relationship from the library artist to their associated catalog content.
+		 * @see https://developer.apple.com/documentation/applemusicapi/libraryartists/relationships-data.dictionary/libraryartistscatalogrelationship
+		 */
+		interface LibraryArtistsCatalogRelationship {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/**
+			 * The artist from the Apple Music catalog associated with the library artist, if any.
+			 */
+			data: MusicKit.Artists[];
+		}
+
+		/**
+		 * A relationship from the album to its artists.
+		 * @see https://developer.apple.com/documentation/applemusicapi/libraryartists/relationships-data.dictionary/libraryartistsalbumsrelationship
+		 */
+		interface LibraryArtistsAlbumsRelationship {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* The relative location to request the next page of resources in the collection, if additional resources are available for fetching. */
+			next?: string;
+			/** The artists for the album. */
+			data: MusicKit.Albums[];
+		}
+
+		interface LibraryArtistsQuery {
+			/** Additional relationships to include in the fetch. */
+			include?: (keyof LibraryArtistsRelationships)[];
+			/** The localization to use, specified by a language tag. The possible values are in the supportedLanguageTags array belonging to the Storefront object specified by storefront. Otherwise, the default is defaultLanguageTag in Storefront. */
+			l?: string;
+			/** The views to activate for the resource. */
+			views?: string[];
+			/** A list of attribute extensions to apply to resources in the response. */
+			extend?: string[];
+		}
+
+		/**
+		 * The response to a library artists request.
+		 * @see https://developer.apple.com/documentation/applemusicapi/artistsresponse
+		 */
+		interface LibraryArtistsResponse {
+			/** The LibraryArtists included in the response for the request. */
+			data: LibraryArtists[];
+		}
+	}
+}
+
+export {};

--- a/src/types/musickit/artist.ts
+++ b/src/types/musickit/artist.ts
@@ -45,6 +45,10 @@ declare global {
 			 * Fetch limits: 25 default, 100 maximum
 			 */
 			albums: ArtistsAlbumsRelationship;
+			/**
+			 * The songs associated with the artist.
+			 */
+			songs: ArtistsSongsRelationship;
 		}
 
 		/**
@@ -59,6 +63,17 @@ declare global {
 			 * The albums for the artist.
 			 */
 			data: MusicKit.Albums[];
+		}
+
+		interface ArtistsSongsRelationship {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/**
+			 * The songs for the artist.
+			 */
+			data: MusicKit.Songs[];
 		}
 
 		interface ArtistsQuery {

--- a/src/types/musickit/library-songs.ts
+++ b/src/types/musickit/library-songs.ts
@@ -37,7 +37,42 @@ declare global {
 			attributes?: LibrarySongsAttributes;
 
 			/** The relationships for the library song. */
-			relationships?: MusicKit.ResourceRelationships;
+			relationships?: MusicKit.LibrarySongsRelationships;
+		}
+
+		/**
+		 * The relationships for a song resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongs/relationships-data.dictionary
+		 */
+		interface LibrarySongsRelationships {
+			/**
+			 * The artists associated with the song. By default, artists includes identifiers only.
+			 * Fetch limits: 10 default, 10 maximum
+			 */
+			artists: MusicKit.SongsArtistsRelationships;
+			/**
+			 * The genres associated with the song. By default, genres is not included.
+			 * Fetch limits: None
+			 */
+			genres: MusicKit.SongsGenresRelationships;
+			/**
+			 * The song in the Apple Music catalog the library song is associated with, when known.
+			 * Fetch limits: None.
+			 */
+			catalog: LibrarySongsCatalogRelationship;
+		}
+
+		/**
+		 * A relationship from the library song to its associated catalog content.
+		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongs/relationships-data.dictionary/librarysongscatalogrelationship
+		 */
+		interface LibrarySongsCatalogRelationship {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/** The song from the Apple Music catalog associated with the library song, if any. */
+			data: MusicKit.Songs[];
 		}
 
 		/**

--- a/src/types/musickit/music-videos.ts
+++ b/src/types/musickit/music-videos.ts
@@ -1,6 +1,6 @@
 declare global {
 	namespace MusicKit {
-		interface LibrarySongsQuery {
+		interface MusicVideosQuery {
 			/** Additional relationships to include in the fetch. */
 			include?: string[];
 			/** The localization to use, specified by a language tag. The possible values are in the supportedLanguageTags array belonging to the Storefront object specified by storefront. Otherwise, the default is defaultLanguageTag in Storefront. */
@@ -14,37 +14,37 @@ declare global {
 		}
 
 		/**
-		 * The response to a library songs request.
-		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongsresponse
+		 * The response to a music videos request.
+		 * @see https://developer.apple.com/documentation/applemusicapi/musicvideosresponse
 		 */
-		interface LibrarySongsResponse {
-			/** The LibrarySongs included in the response for the request. */
-			data: LibrarySongs[];
+		interface MusicVideosResponse {
+			/** The MusicVideos included in the response for the request. */
+			data: MusicVideos[];
 		}
 
 		/**
-		 * A resource object that represents a library song.
-		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongs
+		 * A resource object that represents a music video.
+		 * @see https://developer.apple.com/documentation/applemusicapi/musicvideos
 		 */
-		interface LibrarySongs {
-			/** The identifier for the library song. */
+		interface MusicVideos {
+			/** The identifier for the music video. */
 			id: string;
-			/** This value is always library-songs. */
-			type: "library-songs";
-			/** The relative location for the library song resource. */
+			/** This value is always songs. */
+			type: "music-videos";
+			/** The relative location for the album resource. */
 			href: string;
-			/** The attributes for the library song. */
-			attributes?: LibrarySongsAttributes;
+			/** The attributes for the music video. */
+			attributes?: MusicVideosAttributes;
 
-			/** The relationships for the library song. */
-			relationships?: MusicKit.LibrarySongsRelationships;
+			/** The relationships for the music video. */
+			relationships?: MusicKit.MusicVideosRelationships;
 		}
 
 		/**
 		 * The relationships for a song resource.
-		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongs/relationships-data.dictionary
+		 * @see https://developer.apple.com/documentation/applemusicapi/musicvideos/relationships-data.dictionary
 		 */
-		interface LibrarySongsRelationships {
+		interface MusicVideosRelationships {
 			/**
 			 * The artists associated with the song. By default, artists includes identifiers only.
 			 * Fetch limits: 10 default, 10 maximum
@@ -56,30 +56,30 @@ declare global {
 			 */
 			genres: MusicKit.SongsGenresRelationships;
 			/**
-			 * The song in the Apple Music catalog the library song is associated with, when known.
-			 * Fetch limits: None.
+			 * The songs associated with the music video.
+			 * Fetch limits: 10 default, 10 maximum.
 			 */
-			catalog: LibrarySongsCatalogRelationship;
+			songs: MusicVideosSongsRelationship;
 		}
 
 		/**
-		 * A relationship from the library song to its associated catalog content.
-		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongs/relationships-data.dictionary/librarysongscatalogrelationship
+		 * A relationship from the music video to its associated catalog content.
+		 * @see https://developer.apple.com/documentation/applemusicapi/musicvideos/relationships-data.dictionary/musicvideossongsrelationship
 		 */
-		interface LibrarySongsCatalogRelationship {
+		interface MusicVideosSongsRelationship {
 			/* A relative location for the relationship. */
 			href?: string;
 			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
 			next?: string;
-			/** The song from the Apple Music catalog associated with the library song, if any. */
+			/** The songs associated with the music video. */
 			data: MusicKit.Songs[];
 		}
 
 		/**
-		 * The attributes for a library song resource.
-		 * @see https://developer.apple.com/documentation/applemusicapi/librarysongs/attributes
+		 * The attributes for a music video resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/musicvideos/attributes-data.dictionary
 		 */
-		interface LibrarySongsAttributes {
+		interface MusicVideosAttributes {
 			/** The name of the album the song appears on. */
 			albumName: string;
 			/** The artist’s name. */

--- a/src/types/musickit/objects.ts
+++ b/src/types/musickit/objects.ts
@@ -45,63 +45,6 @@ declare global {
 		}
 
 		/**
-		 * A resource object that represents an album.
-		 * @see https://developer.apple.com/documentation/applemusicapi/albums-uib
-		 */
-		interface Albums {
-			/** The identifier for the album. */
-			id: string;
-			/** This value is always albums. */
-			type: "albums";
-			/** The relative location for the album resource. */
-			href: string;
-			/** The attributes for the album. */
-			attributes?: AlbumsAttributes;
-
-			/** The relationships for the album. */
-			relationships?: MusicKit.ResourceRelationships;
-			/** The relationship views for the album. */
-			views?: MusicKit.ResourceViews;
-		}
-
-		interface AlbumsAttributes {
-			/** The name of the primary artist associated with the album. */
-			artistName: string;
-			/** The URL of the artist for this content. */
-			artistUrl?: string;
-			/** The artwork for the album. */
-			artwork: Artwork;
-			/** Indicates the specific audio variant for the album. */
-			audioVariants?: AudioVariant[];
-			/** The Recording Industry Association of America (RIAA) rating of the content. No value means no rating. */
-			contentRating?: ContentRating;
-			/** The copyright text. */
-			copyright?: string;
-			/** The names of the genres associated with the album. */
-			genreNames: string[];
-			/** Indicates whether the album is marked as a compilation. If true, the album is a compilation; otherwise, it's not. */
-			isCompilation: boolean;
-			/** Indicates whether the album is complete. If true, the album is complete; otherwise, it's not. An album is complete if it contains all its tracks and songs. */
-			isComplete: boolean;
-			/** Indicates whether the album contains a single song. */
-			isSingle: boolean;
-			/** The localized name of the album. */
-			name: string;
-			/** When present, this attribute indicates that one or more tracks on the album are available to play with an Apple Music subscription. The value map may be used to initiate playback of available tracks on the album. */
-			playParams?: PlayParameters;
-			/** The name of the record label for the album. */
-			recordLabel?: string;
-			/** The release date of the album, when known, in YYYY-MM-DD or YYYY format. Prerelease content may have an expected release date in the future. */
-			releaseDate?: string;
-			/** The number of tracks for the album. */
-			trackCount: number;
-			/** The Universal Product Code for the album. */
-			upc?: string;
-			/** The URL for sharing the album in Apple Music. */
-			url?: string;
-		}
-
-		/**
 		 * An object that represents play parameters for resources.
 		 * @see https://developer.apple.com/documentation/applemusicapi/playparameters
 		 */
@@ -136,6 +79,33 @@ declare global {
 			 * For example, {w}x{h}bb.jpeg).
 			 */
 			url: string;
+		}
+
+		/**
+		 * A resource object that represents a music genre.
+		 * @see https://developer.apple.com/documentation/applemusicapi/genres
+		 */
+		interface Genres {
+			/** The identifier for the genre. */
+			id: string;
+			/** This value must always be genres. */
+			type: "genres";
+			/** The relative location for the genre resource. */
+			href: string;
+			/** The attributes for the genre. */
+			attributes?: GenresAttributes;
+		}
+
+		/** The attributes for a genre resource. */
+		interface GenresAttributes {
+			/** The localized name of the genre. */
+			name: string;
+			/** The identifier of the parent for the genre. */
+			parentId?: string;
+			/** The localized name of the parent genre. */
+			parentName?: string;
+			/** (Extended) A localized string to use when displaying the genre in relation to charts. */
+			chartLabel?: string;
 		}
 
 		/**
@@ -208,67 +178,6 @@ declare global {
 		}
 
 		type PlaylistType = "editorial" | "external" | "personal-mix" | "replay" | "user-shared";
-
-		/**
-		 * A resource object that represents a song.
-		 * @see https://developer.apple.com/documentation/applemusicapi/songs-um8
-		 */
-		interface Songs {
-			/** The identifier for the song. */
-			id: string;
-			/** This value is always songs. */
-			type: "songs";
-			/** The relative location for the album resource. */
-			href: string;
-			/** The attributes for the playlist. */
-			attributes?: SongsAttributes;
-
-			/** The relationships for the album. */
-			relationships?: MusicKit.ResourceRelationships;
-		}
-
-		/**
-		 * The attributes for a song resource.
-		 * @see https://developer.apple.com/documentation/applemusicapi/songs/attributes
-		 */
-		interface SongsAttributes {
-			/** The name of the album the song appears on. */
-			albumName: string;
-			/** The artist’s name. */
-			artistName: string;
-			/** The URL of the artist for the content. */
-			artistUrl?: string;
-			/** The album artwork. */
-			artwork: Artwork;
-			/** Indicates the specific audio variant for a song. */
-			audioVariants?: AudioVariant[];
-			/** The song’s composer. */
-			composerName?: string;
-			/** The Recording Industry Association of America (RIAA) rating of the content. No value means no rating. */
-			contentRating?: ContentRating;
-			/** The disc number of the album the song appears on. */
-			discNumber?: number;
-			/** The duration of the song in milliseconds. */
-			durationInMillis: number;
-			/** The genre names the song is associated with. */
-			genreNames: string[];
-			/** Indicates whether the song has lyrics available in the Apple Music catalog. If true, the song has lyrics available; otherwise, it doesn't. */
-			hasLyrics: boolean;
-			/** The International Standard Recording Code (ISRC) for the song. */
-			isrc?: string;
-			/** The localized name of the song. */
-			name: string;
-			/** When present, this attribute indicates that the song is available to play with an Apple Music subscription. The value map may be used to initiate playback. Previews of the song audio may be available with or without an Apple Music subscription. */
-			playParams?: PlayParameters;
-			/** The preview assets for the song. */
-			previews: Preview[];
-			/** The release date of the song, when known, in YYYY-MM-DD or YYYY format. Prerelease songs may have an expected release date in the future. */
-			releaseDate?: string;
-			/** The number of the song in the album’s track list. */
-			trackNumber?: string;
-			/** The URL for sharing the song in Apple Music.  */
-			url: string;
-		}
 	}
 }
 

--- a/src/types/musickit/objects.ts
+++ b/src/types/musickit/objects.ts
@@ -109,41 +109,6 @@ declare global {
 		}
 
 		/**
-		 * A resource object that represents the artist of an album where an artist can be one or more people.
-		 * @see https://developer.apple.com/documentation/applemusicapi/artists-uip
-		 */
-		interface Artists {
-			/** The identifier for the album. */
-			id: string;
-			/** This value is always artists. */
-			type: "artists";
-			/** The relative location for the album resource. */
-			href: string;
-			/** The attributes for the artist. */
-			attributes?: ArtistsAttributes;
-
-			/** The relationships for the album. */
-			relationships?: MusicKit.ResourceRelationships;
-			/** The relationship views for the album. */
-			views?: MusicKit.ResourceViews;
-		}
-
-		/**
-		 * The attributes for an artist resource.
-		 * @see https://developer.apple.com/documentation/applemusicapi/artists/attributes
-		 */
-		interface ArtistsAttributes {
-			/** The artwork for the artist image. */
-			artwork?: Artwork;
-			/** The names of the genres associated with this artist. */
-			genreNames: string[];
-			/** The localized name of the artist. */
-			name: string;
-			/** The URL for sharing the artist in Apple Music. */
-			url: string;
-		}
-
-		/**
 		 * The attributes for a playlist resource.
 		 * @see https://developer.apple.com/documentation/applemusicapi/playlists/attributes
 		 */

--- a/src/types/musickit/playlist.ts
+++ b/src/types/musickit/playlist.ts
@@ -16,8 +16,8 @@ declare global {
 		 * @see https://developer.apple.com/documentation/applemusicapi/playlistsresponse
 		 */
 		interface PlaylistsResponse {
-			/** The LibrarySongs included in the response for the request. */
-			data: MusicKit.Playlists[];
+			/** The Playlists included in the response for the request. */
+			data: Playlists[];
 		}
 
 		/**
@@ -88,7 +88,7 @@ declare global {
 		}
 
 		/**
-		 * A relationship from the playlist to its tracks.
+		 * A relationship from the album to its tracks.
 		 * @see https://developer.apple.com/documentation/applemusicapi/playlists/relationships-data.dictionary/playliststracksrelationship
 		 */
 		interface PlaylistsTracksRelationship {

--- a/src/types/musickit/songs.ts
+++ b/src/types/musickit/songs.ts
@@ -68,6 +68,8 @@ declare global {
 		interface SongsResponse {
 			/** The Songs included in the response for the request. */
 			data: MusicKit.Songs[];
+			/* A relative cursor to fetch the next paginated collection of resources if more exist. */
+			next?: string;
 		}
 
 		/**

--- a/src/types/musickit/songs.ts
+++ b/src/types/musickit/songs.ts
@@ -1,12 +1,120 @@
 declare global {
 	namespace MusicKit {
 		/**
+		 * A resource object that represents a song.
+		 * @see https://developer.apple.com/documentation/applemusicapi/songs-um8
+		 */
+		interface Songs {
+			/** The identifier for the song. */
+			id: string;
+			/** This value is always songs. */
+			type: "songs";
+			/** The relative location for the album resource. */
+			href: string;
+			/** The attributes for the playlist. */
+			attributes?: SongsAttributes;
+
+			/** The relationships for the album. */
+			relationships?: SongsRelationships;
+		}
+
+		/**
+		 * The attributes for a song resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/songs/attributes
+		 */
+		interface SongsAttributes {
+			/** The name of the album the song appears on. */
+			albumName: string;
+			/** The artist’s name. */
+			artistName: string;
+			/** The URL of the artist for the content. */
+			artistUrl?: string;
+			/** The album artwork. */
+			artwork: Artwork;
+			/** Indicates the specific audio variant for a song. */
+			audioVariants?: AudioVariant[];
+			/** The song’s composer. */
+			composerName?: string;
+			/** The Recording Industry Association of America (RIAA) rating of the content. No value means no rating. */
+			contentRating?: ContentRating;
+			/** The disc number of the album the song appears on. */
+			discNumber?: number;
+			/** The duration of the song in milliseconds. */
+			durationInMillis: number;
+			/** The genre names the song is associated with. */
+			genreNames: string[];
+			/** Indicates whether the song has lyrics available in the Apple Music catalog. If true, the song has lyrics available; otherwise, it doesn't. */
+			hasLyrics: boolean;
+			/** The International Standard Recording Code (ISRC) for the song. */
+			isrc?: string;
+			/** The localized name of the song. */
+			name: string;
+			/** When present, this attribute indicates that the song is available to play with an Apple Music subscription. The value map may be used to initiate playback. Previews of the song audio may be available with or without an Apple Music subscription. */
+			playParams?: PlayParameters;
+			/** The preview assets for the song. */
+			previews: Preview[];
+			/** The release date of the song, when known, in YYYY-MM-DD or YYYY format. Prerelease songs may have an expected release date in the future. */
+			releaseDate?: string;
+			/** The number of the song in the album’s track list. */
+			trackNumber?: string;
+			/** The URL for sharing the song in Apple Music.  */
+			url: string;
+		}
+
+		/**
 		 * The response to a songs request.
 		 * @see https://developer.apple.com/documentation/applemusicapi/songsresponse
 		 */
 		interface SongsResponse {
 			/** The Songs included in the response for the request. */
 			data: MusicKit.Songs[];
+		}
+
+		/**
+		 * The relationships for a song resource.
+		 * @see https://developer.apple.com/documentation/applemusicapi/songs/relationships-data.dictionary
+		 */
+		interface SongsRelationships {
+			/**
+			 * The artists associated with the song. By default, artists includes identifiers only.
+			 * Fetch limits: 10 default, 10 maximum
+			 */
+			artists: SongsArtistsRelationships;
+			/**
+			 * The genres associated with the song. By default, genres is not included.
+			 * Fetch limits: None
+			 */
+			genres: SongsGenresRelationships;
+		}
+
+		/**
+		 * A relationship from the song to its artists.
+		 * @see https://developer.apple.com/documentation/applemusicapi/songs/relationships-data.dictionary/songsartistsrelationship
+		 */
+		interface SongsArtistsRelationships {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/**
+			 * The artists associated with the song.
+			 */
+			data: MusicKit.Artists[];
+		}
+
+		/**
+		 * A relationship from the song to its genres.
+		 * @see https://developer.apple.com/documentation/applemusicapi/songs/relationships-data.dictionary/songsgenresrelationship
+		 */
+		interface SongsGenresRelationships {
+			/* A relative location for the relationship. */
+			href?: string;
+			/* A relative cursor to fetch the next paginated collection of resources in the relationship if more exist. */
+			next?: string;
+			/**
+			 * The artists associated with the song.
+			 */
+			data: MusicKit.Genres[];
 		}
 
 		/**

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -13,3 +13,20 @@ export function generateUUID(): string {
 	const view = new DataView(data.buffer);
 	return `${asHex(view.getUint32(0), 8)}-${asHex(view.getUint16(4), 4)}-${asHex(view.getUint16(6), 4)}-${asHex(view.getUint16(8), 4)}-${asHex(view.getUint32(10), 8)}${asHex(view.getUint16(14), 4)}`;
 }
+
+export function generateHash(data: string, seed = 0): number {
+	// https://stackoverflow.com/a/52171480/14053734
+	let h1 = 0xdeadbeef ^ seed,
+		h2 = 0x41c6ce57 ^ seed;
+	for (let i = 0, ch; i < data.length; i++) {
+		ch = data.charCodeAt(i);
+		h1 = Math.imul(h1 ^ ch, 2654435761);
+		h2 = Math.imul(h2 ^ ch, 1597334677);
+	}
+	h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+	h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+	h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+	h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
+	return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}

--- a/src/utils/songs.ts
+++ b/src/utils/songs.ts
@@ -1,15 +1,20 @@
-import { Artist, ArtistPreview, Filled, Song, SongType } from "@/services/Music/objects";
+import {
+	DisplayableArtist,
+	Filled,
+	filledDisplayableArtist,
+	Song,
+	SongType,
+} from "@/services/Music/objects";
 import { LocalImage, useLocalImages } from "@/stores/local-images";
 
-export function formatArtists(
-	artists?: (Filled<Artist> | Filled<ArtistPreview> | Artist)[],
-): string {
+export function formatArtists(artists?: (DisplayableArtist | Filled<DisplayableArtist>)[]): string {
 	if (!artists?.length) {
 		return "Unknown artist(s)";
 	}
-	let formatted = artists[0]!.title;
+
+	let formatted = filledDisplayableArtist(artists[0]!).title;
 	for (let i = 1; i < artists.length; ++i) {
-		formatted += ` & ${artists[i]!.title}`;
+		formatted += ` & ${filledDisplayableArtist(artists[i]!).title}`;
 	}
 	return formatted;
 }

--- a/src/utils/songs.ts
+++ b/src/utils/songs.ts
@@ -1,18 +1,24 @@
+import { Artist, ArtistPreview, Filled, Song, SongType } from "@/services/Music/objects";
 import { LocalImage, useLocalImages } from "@/stores/local-images";
-import { AnySong } from "@/stores/music-player";
 
-export function formatArtists(artists?: string[]): string {
-	if (!artists) {
+export function formatArtists(
+	artists?: (Filled<Artist> | Filled<ArtistPreview> | Artist)[],
+): string {
+	if (!artists?.length) {
 		return "Unknown artist(s)";
 	}
-	return artists.join(" & ");
+	let formatted = artists[0]!.title;
+	for (let i = 1; i < artists.length; ++i) {
+		formatted += ` & ${artists[i]!.title}`;
+	}
+	return formatted;
 }
 
 export function formatGenres(genres?: string[]): string {
 	return genres?.join(", ") || "Unknown genre(s)";
 }
 
-export function songTypeToDisplayName(type?: AnySong["type"]): string {
+export function songTypeToDisplayName(type?: SongType): string {
 	switch (type) {
 		case "local":
 			return "Local";
@@ -34,7 +40,7 @@ const intensity = ([r, g, b]: Uint8ClampedArray): number => {
  * @param artworkUrl
  * @returns
  */
-export async function generateSongStyle(artwork?: LocalImage): Promise<AnySong["style"]> {
+export async function generateSongStyle(artwork?: LocalImage): Promise<Song["style"]> {
 	if (!artwork) {
 		return {
 			fgColor: "#ffffff",

--- a/src/utils/songs.ts
+++ b/src/utils/songs.ts
@@ -2,14 +2,17 @@ import { LocalImage, useLocalImages } from "@/stores/local-images";
 import { AnySong } from "@/stores/music-player";
 
 export function formatArtists(artists?: string[]): string {
-	return artists?.join?.(" & ") || "Unknown artist(s)";
+	if (!artists) {
+		return "Unknown artist(s)";
+	}
+	return artists.join(" & ");
 }
 
 export function formatGenres(genres?: string[]): string {
 	return genres?.join(", ") || "Unknown genre(s)";
 }
 
-export function songTypeToDisplayName(type: AnySong["type"]): string {
+export function songTypeToDisplayName(type?: AnySong["type"]): string {
 	switch (type) {
 		case "local":
 			return "Local";
@@ -17,6 +20,8 @@ export function songTypeToDisplayName(type: AnySong["type"]): string {
 			return "Apple Music";
 		case "youtube":
 			return "YouTube";
+		default:
+			return "Unknown service";
 	}
 }
 

--- a/src/utils/vue.ts
+++ b/src/utils/vue.ts
@@ -1,5 +1,5 @@
 import { MaybeRefOrGetter } from "@vueuse/core";
-import { useIDBKeyval, UseIDBOptions } from "@vueuse/integrations/useIDBKeyval";
+import { useIDBKeyval, UseIDBOptions } from "@vueuse/integrations/useIDBKeyval.mjs";
 import { computed, onMounted, ref, Ref, watch } from "vue";
 
 export async function useIDBKeyvalAsync<T>(

--- a/src/utils/vue.ts
+++ b/src/utils/vue.ts
@@ -1,6 +1,26 @@
 import { MaybeRefOrGetter } from "@vueuse/core";
 import { useIDBKeyval, UseIDBOptions } from "@vueuse/integrations/useIDBKeyval.mjs";
-import { computed, onMounted, ref, Ref, watch, WatchHandle, WatchOptions, WatchSource } from "vue";
+import {
+	computed,
+	markRaw,
+	onMounted,
+	ref,
+	Ref,
+	watch,
+	WatchHandle,
+	WatchOptions,
+	WatchSource,
+} from "vue";
+
+export function markRawDeep<T extends object>(object: T): T {
+	markRaw(object);
+	for (const value of Object.values(object)) {
+		if (typeof value === "object") {
+			markRaw(value);
+		}
+	}
+	return object;
+}
 
 export async function useIDBKeyvalAsync<T>(
 	key: IDBValidKey,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import capacitorConfig from "./capacitor.config";
 // https://vitejs.dev/config/
 export default defineConfig({
 	plugins: [vue()],
-	build: { outDir: capacitorConfig.webDir },
+	build: { outDir: capacitorConfig.webDir, sourcemap: "inline" },
 	define: {
 		__IS_ELECTRON__: "false",
 	},


### PR DESCRIPTION
This PR adds support for Albums and Artists, both individual pages as well as in library.

 - Library page
   - Albums
     - [x] Apple Music
     - [x] Local
     - [ ] YouTube (TBD)
   - Artists
     - [x] Apple Music
     - [x] Local
     - [ ] YouTube (TBD)
 - Album pages
   - [x] Apple Music
   - [x] Local
   - [x] YouTube 
 - Artist pages
   - [x] Apple Music
   - [x] Local
   - [x] YouTube